### PR TITLE
refactor(engine): 멀티키 빌더 발판 — .edit 타입 + PendingCommand/step 재배선 (무동작)

### DIFF
--- a/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
@@ -2,6 +2,35 @@
 /// "어떻게 실행하는가"(AX 호출인지 키 합성인지)는 전략 어댑터의 몫이다.
 public enum VimAction: Hashable, Sendable {
     case move(Motion)
+    case edit(Operator, TextRange)
+}
+
+/// 편집 오퍼레이터의 종류. 적용 범위는 `TextRange`가 함께 나른다.
+public enum Operator: Hashable, Sendable {
+    case delete
+}
+
+/// 오퍼레이터가 적용될 범위.
+public enum TextRange: Hashable, Sendable {
+    /// 커서에서 모션을 count회 적용한 지점까지 — 한 편집 단위다 (`d3w`는
+    /// move 3회 반복이 아니라 3단어를 한 번에 지우는 범위).
+    case motion(Motion, count: Int)
+    /// 커서가 놓인 텍스트 오브젝트 — `diw`/`daw`.
+    case textObject(TextObject)
+    /// 현재 줄부터 count줄 — `dd`, `2dd`.
+    case line(count: Int)
+}
+
+/// 텍스트 오브젝트. 경계의 실제 의미(단어의 정의, 주변 공백 포함 범위)는
+/// 어댑터가 정하며, 엔진은 종류와 스코프만 낸다.
+public enum TextObject: Hashable, Sendable {
+    case word(Scope)
+
+    /// `i`(inner: 오브젝트 본체만) / `a`(around: 주변 공백 포함).
+    public enum Scope: Hashable, Sendable {
+        case inner
+        case around
+    }
 }
 
 /// 커서 이동의 종류. 단어 경계·줄 경계의 실제 의미(어디까지가 단어인가 등)는

--- a/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
@@ -3,33 +3,33 @@
 public enum VimAction: Hashable, Sendable {
     case move(Motion)
     case edit(Operator, TextRange)
-}
 
-/// 편집 오퍼레이터의 종류. 적용 범위는 `TextRange`가 함께 나른다.
-public enum Operator: Hashable, Sendable {
-    case delete
-}
+    /// 편집 오퍼레이터의 종류. 적용 범위는 `TextRange`가 함께 나른다.
+    public enum Operator: Hashable, Sendable {
+        case delete
+    }
 
-/// 오퍼레이터가 적용될 범위.
-public enum TextRange: Hashable, Sendable {
-    /// 커서에서 모션을 count회 적용한 지점까지 — 한 편집 단위다 (`d3w`는
-    /// move 3회 반복이 아니라 3단어를 한 번에 지우는 범위).
-    case motion(Motion, count: Int)
-    /// 커서가 놓인 텍스트 오브젝트 — `diw`/`daw`.
-    case textObject(TextObject)
-    /// 현재 줄부터 count줄 — `dd`, `2dd`.
-    case line(count: Int)
-}
+    /// 오퍼레이터가 적용될 범위.
+    public enum TextRange: Hashable, Sendable {
+        /// 커서에서 모션을 count회 적용한 지점까지 — 한 편집 단위다 (`d3w`는
+        /// move 3회 반복이 아니라 3단어를 한 번에 지우는 범위).
+        case motion(Motion, count: Int)
+        /// 커서가 놓인 텍스트 오브젝트 — `diw`/`daw`.
+        case textObject(TextObject)
+        /// 현재 줄부터 count줄 — `dd`, `2dd`.
+        case line(count: Int)
+    }
 
-/// 텍스트 오브젝트. 경계의 실제 의미(단어의 정의, 주변 공백 포함 범위)는
-/// 어댑터가 정하며, 엔진은 종류와 스코프만 낸다.
-public enum TextObject: Hashable, Sendable {
-    case word(Scope)
+    /// 텍스트 오브젝트. 경계의 실제 의미(단어의 정의, 주변 공백 포함 범위)는
+    /// 어댑터가 정하며, 엔진은 종류와 스코프만 낸다.
+    public enum TextObject: Hashable, Sendable {
+        case word(Scope)
 
-    /// `i`(inner: 오브젝트 본체만) / `a`(around: 주변 공백 포함).
-    public enum Scope: Hashable, Sendable {
-        case inner
-        case around
+        /// `i`(inner: 오브젝트 본체만) / `a`(around: 주변 공백 포함).
+        public enum Scope: Hashable, Sendable {
+            case inner
+            case around
+        }
     }
 }
 

--- a/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
@@ -10,7 +10,7 @@ public struct VimEngine: Sendable {
         /// 선행 카운트 — `3w`의 3, `2dd`의 2.
         var count: Int?
         /// 대기 중인 오퍼레이터 — `d`.
-        var op: Operator?
+        var op: VimAction.Operator?
         /// 오퍼레이터 뒤 카운트 — `d3w`의 3. 유효 카운트는 두 카운트의 곱이다 (`2d3w` = 6).
         var opCount: Int?
         /// 완결 키 하나를 기다리는 접두. `op` 유무로 두 케이스가 구분된다.
@@ -20,7 +20,7 @@ public struct VimEngine: Sendable {
             /// `g` — `gg` 대기 (`op == nil`일 때만).
             case g
             /// `di`/`da` 후 오브젝트 키 대기 (`op != nil` 보장).
-            case textObjectScope(TextObject.Scope)
+            case textObjectScope(VimAction.TextObject.Scope)
         }
     }
 
@@ -88,12 +88,20 @@ public struct VimEngine: Sendable {
         pending = nil
 
         // 접두(prefix)는 완결 키 하나만 기다린다 — 다른 어떤 매핑보다 먼저 본다.
+        // 케이스 망라 switch라 Prefix가 늘면 여기서 컴파일이 깨진다 — 새 접두가
+        // 아래 일반 매핑으로 새는 실수를 타입으로 막는다.
         // `gi` 같은 실제 Vim 커맨드도 지원 전까지는 invalid로 떨어진다.
-        if case .g = current.prefix {
-            if key == .char("g") {
-                return .replace([.move(.documentStart)])
+        if let prefix = current.prefix {
+            switch prefix {
+            case .g:
+                if key == .char("g") {
+                    return .replace([.move(.documentStart)])
+                }
+                return .swallow
+            case .textObjectScope:
+                // 생산 경로 없음 — `di`/`da`를 만드는 Phase 3에서 구현한다.
+                return .swallow
             }
-            return .swallow
         }
 
         switch key {

--- a/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
@@ -141,7 +141,6 @@ public struct VimEngine: Sendable {
 
     /// 탈출 modifier(예: Cmd/Opt)와 교집합이 있는 콤보인지 — Spotlight/Raycast 등
     /// 시스템 단축키 직후의 타이핑을 막지 않기 위해 이런 콤보는 Insert로 탈출시킨다.
-    /// Normal의 미매핑 콤보 분기와 pending 해소 분기가 같은 판정을 공유한다.
     private func isEscapeCombo(_ key: Key) -> Bool {
         !key.modifiers.isDisjoint(with: configuration.normalModeEscapeModifiers)
     }

--- a/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
@@ -3,16 +3,31 @@
 /// 이 타입은 macOS를 전혀 알지 못한다 — AX 호출, 키 이벤트 합성, 최전면 앱 인식을
 /// 하지 않는다. 그런 로직은 전략 디스패처/어댑터의 몫이며, 여기 들어오면 안 된다.
 public struct VimEngine: Sendable {
-    /// Normal 모드에서 멀티키 시퀀스의 나머지 키를 기다리는 상태 (모드 외 유일한 내부 상태).
+    /// Normal 모드에서 누적 중인 부분 커맨드 (모드 외 유일한 내부 상태).
+    /// `3w`·`dd`·`diw` 같은 멀티키 커맨드의 문법 슬롯을 채워가는 빌더이며,
     /// 무효한 연속 키가 오면 pending과 그 키를 함께 버리는 no-op이다 (Vim의 무효 커맨드 동작).
-    private enum Pending: Sendable {
-        case g
+    private struct PendingCommand: Sendable {
+        /// 선행 카운트 — `3w`의 3, `2dd`의 2.
+        var count: Int?
+        /// 대기 중인 오퍼레이터 — `d`.
+        var op: Operator?
+        /// 오퍼레이터 뒤 카운트 — `d3w`의 3. 유효 카운트는 두 카운트의 곱이다 (`2d3w` = 6).
+        var opCount: Int?
+        /// 완결 키 하나를 기다리는 접두. `op` 유무로 두 케이스가 구분된다.
+        var prefix: Prefix?
+
+        enum Prefix: Sendable {
+            /// `g` — `gg` 대기 (`op == nil`일 때만).
+            case g
+            /// `di`/`da` 후 오브젝트 키 대기 (`op != nil` 보장).
+            case textObjectScope(TextObject.Scope)
+        }
     }
 
     /// 현재 모드. 시작 모드는 Insert — 기본적으로 앱의 평소 타이핑을 방해하지 않는다.
     public private(set) var mode: Mode
 
-    private var pending: Pending?
+    private var pending: PendingCommand?
 
     /// 주입된 동작 설정. 기본값(빈 셋)은 기존 동작을 그대로 유지한다.
     private let configuration: Configuration
@@ -42,9 +57,43 @@ public struct VimEngine: Sendable {
     }
 
     private mutating func handleNormal(_ key: Key) -> EngineOutput {
-        if let pending {
-            self.pending = nil
-            return resolve(pending, then: key)
+        // 취소 — 어떤 매핑보다 우선하는 cross-cutting 규칙 (step 진입 전).
+        //
+        // Esc는 정확 매치(수식자 없음)로 pending을 폐기하고 Normal에 머문다.
+        // 탈출 modifier 콤보는 커맨드 입력 도중이라도 pending을 폐기하고 Insert로
+        // 탈출시킨다 — 시스템 단축키(Spotlight/Raycast 등) 직후 타이핑을 막지
+        // 않기 위함. 수식자 붙은 Esc(Cmd+Esc 등)는 Esc 분기가 아니라 이 판정을 탄다.
+        if key == .escape {
+            pending = nil
+            return .swallow
+        }
+        if isEscapeCombo(key) {
+            pending = nil
+            mode = .insert
+            return .passthrough
+        }
+
+        return step(key)
+    }
+
+    /// 누적 중인 부분 커맨드를 이번 키로 한 스텝 진행시킨다 — 결과는 셋 중 하나다.
+    ///
+    /// - extend: 문법이 계속되면 pending에 슬롯을 채워 유지한다 (`g`, 이후 카운트·오퍼레이터).
+    /// - complete: 커맨드가 완결되면 pending을 비우고 액션을 낸다.
+    /// - invalid: 무효한 연속이면 pending과 이번 키를 함께 버리는 no-op이다.
+    ///
+    /// 진입 시 pending을 비워두므로 extend 경로만 명시적으로 되채운다.
+    private mutating func step(_ key: Key) -> EngineOutput {
+        let current = pending ?? PendingCommand()
+        pending = nil
+
+        // 접두(prefix)는 완결 키 하나만 기다린다 — 다른 어떤 매핑보다 먼저 본다.
+        // `gi` 같은 실제 Vim 커맨드도 지원 전까지는 invalid로 떨어진다.
+        if case .g = current.prefix {
+            if key == .char("g") {
+                return .replace([.move(.documentStart)])
+            }
+            return .swallow
         }
 
         switch key {
@@ -61,7 +110,9 @@ public struct VimEngine: Sendable {
             mode = .insert
             return .replace([.move(.lineEndForAppend)])
         case .char("g"):
-            pending = .g
+            var next = current
+            next.prefix = .g
+            pending = next
             return .swallow
         default:
             break
@@ -72,38 +123,12 @@ public struct VimEngine: Sendable {
         }
 
         // 매핑 없는 modifier 조합(Cmd+C 등)은 시스템 단축키이므로 통과시킨다.
+        // (탈출 콤보는 handleNormal이 이미 걸렀으므로 여기는 비탈출 콤보만 온다.)
         // modifier 없는 미매핑 키만 삼킨다 (Normal 모드 키가 앱에 새지 않게).
         if key.modifiers.isEmpty {
             return .swallow
         }
-        if isEscapeCombo(key) {
-            mode = .insert
-        }
         return .passthrough
-    }
-
-    /// 소비된 pending 접두를 다음 키로 해소한다. `self.pending`은 호출부
-    /// (`handleNormal`)가 진입 시 이미 비웠으므로 어느 경로로 빠지든 pending은
-    /// 남지 않는다 — 여기서 정하는 건 "이번 키로 무엇을 낼지"뿐이다.
-    ///
-    /// - 유효한 연속(`gg`): 해당 모션을 낸다.
-    /// - 탈출 modifier 콤보: Insert로 전이하며 통과시킨다 — `g` 입력 도중이라도
-    ///   시스템 단축키(Spotlight/Raycast 등) 직후 타이핑을 막지 않기 위함.
-    /// - 그 외(Esc 포함): no-op으로 삼키고 Normal에 머문다. `gi`(마지막 삽입
-    ///   위치로 insert) 같은 실제 Vim 커맨드도 지원 전까지는 여기로 떨어진다.
-    private mutating func resolve(_ pending: Pending, then key: Key) -> EngineOutput {
-        if isEscapeCombo(key) {
-            mode = .insert
-            return .passthrough
-        }
-
-        switch pending {
-        case .g:
-            if key == .char("g") {
-                return .replace([.move(.documentStart)])
-            }
-            return .swallow
-        }
     }
 
     /// 탈출 modifier(예: Cmd/Opt)와 교집합이 있는 콤보인지 — Spotlight/Raycast 등

--- a/Packages/VimActionCore/Tests/VimEngineTests/EscapeModifierFixtures.swift
+++ b/Packages/VimActionCore/Tests/VimEngineTests/EscapeModifierFixtures.swift
@@ -73,6 +73,18 @@ let escapeModifierFixtures: [KeySequenceFixture] = [
         steps: [step(.init(.space, [.command]), .passthrough)],
         finalMode: .insert
     ),
+    // 수식자 붙은 Esc는 "Esc 취소" 분기(정확 매치)가 아니라 escapeCombo 판정을 탄다.
+    // Esc를 base 매치로 구현하면 이 케이스가 swallow+Normal로 뒤집혀 여기서 잡힌다.
+    KeySequenceFixture(
+        "탈출 옵션 켜진 Normal에서 g 후 Cmd+Esc → Esc 취소가 아니라 탈출 콤보로 통과하며 Insert",
+        startMode: .normal,
+        configuration: escapeOnCmdOpt,
+        steps: [
+            step(.char("g"), .swallow),
+            step(.init(.escape, [.command]), .passthrough),
+        ],
+        finalMode: .insert
+    ),
     // 탈출 목적 자체 확인 — 복귀 후 후속 문자 키가 타이핑으로 통과
     KeySequenceFixture(
         "탈출 옵션으로 Insert 복귀 후 후속 문자 키(a)는 타이핑으로 통과",


### PR DESCRIPTION
## 요약

멀티키 커맨드 빌더(Plan-2)의 **Phase 0 — 동작 변화 없는 발판 리팩터**. 이후 카운트(`3w`)·오퍼레이터(`dd`, `d`+모션)·텍스트 오브젝트(`diw`/`daw`)가 얹힐 골격을 깔고, Plan-1(탭↔엔진 배선)과 공유하는 `VimAction` 계약을 선고정한다.

- `VimAction`에 `.edit(Operator, TextRange)` + `Operator`/`TextRange`/`TextObject` 타입 추가 (아직 생산하는 경로 없음 — **계약 선고정 목적**. Plan-1이 이 enum 위에서 개발하면 머지 순서와 무관해진다)
- `Pending` enum(`case g`) → `PendingCommand` 구조체(count/op/opCount/prefix) — 문법 빌더 골격
- `handleNormal` = **취소 최우선**(Esc 정확 매치 / 탈출 modifier 콤보) + `step`(extend/complete/invalid) 재배선 — 기존 "진입부 무조건 pending 클리어"의 부수효과였던 취소를 명시적 분기로 승격
- **Cmd+Esc 회귀 핀** 추가: 수식자 붙은 Esc는 Esc 취소가 아니라 escapeCombo 판정을 탄다 (Esc를 base 매치로 구현하는 실수를 잡는 픽스처)

설계 근거: `.claude/skills/decisions/references/20260714_multikey-command-grammar-builder.md`, 실행 플랜: `.claude/skills/plans/references/20260714_multikey-command-builder.md`

## 검증

- `swift test` 9/9 그린 — **기존 픽스처 전부 무수정 통과** (무동작 리팩터의 성공 기준) + Cmd+Esc 핀
- `xcodebuild -scheme VimAction build` 성공 — `.edit` 추가가 앱 타깃을 깨지 않음 (앱은 `VimAction`을 패턴매칭하지 않음)

## 후속

Phase 1~6(카운트→x→d+모션/dd→diw/daw→취소 매트릭스→문서화)은 이 브랜치 위에 stacked PR로 이어진다. 이 PR을 먼저 머지하면 Plan-1과의 계약이 main에 고정된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)