### PR TITLE
feat(engine): c/y 오퍼레이터 일반화 — cc/yy·모션·텍스트 오브젝트 조합, change→Insert 전이

### DIFF
--- a/.claude/skills/plans/references/20260719_engine-operators-textobjects-linewise.md
+++ b/.claude/skills/plans/references/20260719_engine-operators-textobjects-linewise.md
@@ -12,6 +12,7 @@
 ## 완료된 것
 
 - [x] 플랜 수립 + 확정 설계 (2026-07-19, 사용자 요청 — 병렬 후보 1·2번 채택)
+- [x] **c/y 오퍼레이터 일반화** (2026-07-19, `swift test` GREEN + 리뷰 패널 3종 통과) — `operatorKeys` 테이블(진입·자기 키 반복 공용), `complete` 헬퍼(change→Insert 전이 단일화), `OperatorFixtures.swift` 34케이스 + 취소 매트릭스 `c`/`ci` 깊이 추가. `cg`/`cj` 이연 핀은 linewise 단계에서 갱신될 churn을 사용자 승인 하에 추가.
 
 ## 확정 설계 (구현 착수 기준선)
 
@@ -58,10 +59,9 @@ case linewiseMotion(Motion, count: Int)
 
 ## 남은 것
 
-- [ ] **c/y 오퍼레이터 일반화**: 위 "오퍼레이터 일반화" 설계대로. GREEN: `swift test` 전체 통과 (기존 픽스처 무회귀 포함).
 - [ ] **텍스트 오브젝트 확장**: quote·pair. GREEN: `swift test`.
 - [ ] **linewise TextRange**: `.linewiseMotion` + 화이트리스트 + `dgg` 문법. GREEN: `swift test`.
-- [ ] **기록**: decisions 3건(change의 Insert 전이 + cw 특례 어댑터 이연 / TextObject 확장 형태와 키 매핑 경계 / linewise 표현 + 절대-모션-카운트 invalid 기준) + architecture `mode-engine.md` 갱신(구현 키셋·opMotion 이연 문구 해소·타입 목록).
+- [ ] **기록**: decisions 3건(change의 Insert 전이 + cw 특례 어댑터 이연 — **change 완결 즉시 전이와 어댑터 실행의 인터리빙 리스크·"어댑터는 change 삭제 실행 후 후속 이벤트 처리" 계약 명시(사용자 확인됨)** / TextObject 확장 형태와 키 매핑 경계 / linewise 표현 + 절대-모션-카운트 invalid 기준) + architecture `mode-engine.md` 갱신(구현 키셋·opMotion 이연 문구 해소·타입 목록).
 
 ## 진행 중 컨텍스트
 

--- a/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
@@ -7,6 +7,9 @@ public enum VimAction: Hashable, Sendable {
     /// 편집 오퍼레이터의 종류. 적용 범위는 `TextRange`가 함께 나른다.
     public enum Operator: Hashable, Sendable {
         case delete
+        /// 범위를 지우고 입력을 시작한다 — 엔진이 완결 시 Insert로 전이한다.
+        case change
+        case yank
     }
 
     /// 오퍼레이터가 적용될 범위.

--- a/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimEngine.swift
@@ -9,7 +9,7 @@ public struct VimEngine: Sendable {
     private struct PendingCommand: Sendable {
         /// 선행 카운트 — `3w`의 3, `2dd`의 2.
         var count: Int?
-        /// 대기 중인 오퍼레이터 — `d`.
+        /// 대기 중인 오퍼레이터 — `d`/`c`/`y`.
         var op: VimAction.Operator?
         /// 오퍼레이터 뒤 카운트 — `d3w`의 3. 유효 카운트는 두 카운트의 곱이다 (`2d3w` = 6).
         var opCount: Int?
@@ -102,7 +102,7 @@ public struct VimEngine: Sendable {
         case .textObjectScope(let scope):
             // di/da로만 진입하므로 op != nil이 보장된다. 1차 오브젝트는 word만.
             if key == .char("w"), let op = current.op {
-                return .replace([.edit(op, .textObject(.word(scope)))])
+                return complete(op, .textObject(.word(scope)))
             }
             return .swallow
         case nil:
@@ -133,15 +133,24 @@ public struct VimEngine: Sendable {
             // 9,999 클램프를 우회할 수 있어(9999d9999w ≈ 1e8) 동일 상한으로 다시
             // 클램프한다 — 소비자가 신뢰하는 카운트 상한을 곱 경로도 지키게 한다.
             let effectiveCount = min((current.count ?? 1) * (current.opCount ?? 1), Self.maxCount)
-            // 오퍼레이터 키 반복(dd)은 줄 단위 범위다.
-            if key == .char("d"), op == .delete {
-                return .replace([.edit(op, .line(count: effectiveCount))])
+            // 오퍼레이터 키 반복(dd/cc/yy)은 줄 단위 범위다. 혼합(dc, yd 등)은
+            // 문법에 없으므로 아래 invalid로 떨어진다.
+            if Self.operatorKeys[key] == op {
+                return complete(op, .line(count: effectiveCount))
             }
             if let motion = Self.operatorMotions[key] {
-                return .replace([.edit(op, .motion(motion, count: effectiveCount))])
+                return complete(op, .motion(motion, count: effectiveCount))
             }
             // 화이트리스트 밖은 전부 invalid — dq 같은 무효 키와 dj/dk/dG
             // (linewise — TextRange에 구분이 생길 때까지 이연)를 포함한다.
+            return .swallow
+        }
+
+        // 최상위 오퍼레이터 키(d/c/y) — op 슬롯을 채우고 다음 키를 기다린다.
+        if let op = Self.operatorKeys[key] {
+            var next = current
+            next.op = op
+            pending = next
             return .swallow
         }
 
@@ -161,11 +170,6 @@ public struct VimEngine: Sendable {
         case .char("g"):
             var next = current
             next.prefix = .g
-            pending = next
-            return .swallow
-        case .char("d"):
-            var next = current
-            next.op = .delete
             pending = next
             return .swallow
         case .char("x"):
@@ -200,6 +204,15 @@ public struct VimEngine: Sendable {
         return .passthrough
     }
 
+    /// 커맨드 완결 공통 경로 — change는 편집 출력과 함께 Insert로 전이한다
+    /// (`cc`/`c$`/`ciw` 전부, `a`/`A`의 전이+출력 동시 패턴과 동일).
+    private mutating func complete(_ op: VimAction.Operator, _ range: VimAction.TextRange) -> EngineOutput {
+        if op == .change {
+            mode = .insert
+        }
+        return .replace([.edit(op, range)])
+    }
+
     /// 탈출 modifier(예: Cmd/Opt)와 교집합이 있는 콤보인지 — Spotlight/Raycast 등
     /// 시스템 단축키 직후의 타이핑을 막지 않기 위해 이런 콤보는 Insert로 탈출시킨다.
     private func isEscapeCombo(_ key: Key) -> Bool {
@@ -225,6 +238,14 @@ public struct VimEngine: Sendable {
     private static func accumulate(_ count: Int?, digit: Int) -> Int {
         min((count ?? 0) * 10 + digit, maxCount)
     }
+
+    /// 최상위에서 op 슬롯을 여는 오퍼레이터 키. 오퍼레이터 대기 중 "자신의 키"
+    /// 반복(dd/cc/yy = 줄 범위) 판정에도 같은 테이블을 쓴다.
+    private static let operatorKeys: [Key: VimAction.Operator] = [
+        .char("d"): .delete,
+        .char("c"): .change,
+        .char("y"): .yank,
+    ]
 
     /// 오퍼레이터 뒤에 올 수 있는 모션 — charwise-safe 집합만. `j`/`k`/`G`는
     /// Vim에서 linewise 범위(`dj` = 두 줄 통삭제)인데 `TextRange.motion`엔

--- a/Packages/VimActionCore/Tests/VimEngineTests/CancellationFixtures.swift
+++ b/Packages/VimActionCore/Tests/VimEngineTests/CancellationFixtures.swift
@@ -20,6 +20,9 @@ private let pendingDepths: [(label: String, keys: [Key])] = [
     ("카운트 두 자리 입력 중(12)", [.char("1"), .char("2")]),
     ("오퍼레이터 대기(d)", [.char("d")]),
     ("스코프 대기(di)", [.char("d"), .char("i")]),
+    // change는 완결 시 Insert로 전이하므로, 취소가 전이를 유발하지 않음을 별도로 편다.
+    ("오퍼레이터 대기(c)", [.char("c")]),
+    ("스코프 대기(ci)", [.char("c"), .char("i")]),
     ("오퍼레이터 카운트 입력 중(d3)", [.char("d"), .char("3")]),
     ("전체 슬롯 사용 중(2d3)", [.char("2"), .char("d"), .char("3")]),
 ]

--- a/Packages/VimActionCore/Tests/VimEngineTests/OperatorFixtures.swift
+++ b/Packages/VimActionCore/Tests/VimEngineTests/OperatorFixtures.swift
@@ -1,0 +1,230 @@
+import Testing
+
+@testable import VimEngine
+
+/// c/y 오퍼레이터 픽스처 — 오퍼레이터 배관 일반화의 커버.
+/// d 계열은 `EditFixtures.swift`가 담당하고, 여기는 change/yank 고유 동작
+/// (change의 Insert 전이, yank의 Normal 유지)과 혼합 오퍼레이터 invalid를 편다.
+
+// 오퍼레이터 뒤 모션 화이트리스트 — d와 같은 charwise-safe 집합 8종.
+private let operatorMotionKeys: [(Character, Motion)] = [
+    ("w", .wordForward),
+    ("b", .wordBackward),
+    ("e", .wordEndForward),
+    ("h", .charLeft),
+    ("l", .charRight),
+    ("0", .lineStart),
+    ("^", .lineFirstNonBlank),
+    ("$", .lineEnd),
+]
+
+// change는 완결과 함께 Insert로 전이한다. cw 특례(Vim의 ce 동작)는 엔진이
+// 흉내내지 않는다 — 특례 조건(커서가 공백 위인지)은 버퍼 문맥이 필요해 엔진이
+// 판단 불가. literal 출력을 내고 의미 복원은 어댑터 몫이다.
+let changeMotionFixtures: [KeySequenceFixture] = operatorMotionKeys.map { key, motion in
+    KeySequenceFixture(
+        "c\(key) → change over \(motion), Insert 전이",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char(key), .replace([.edit(.change, .motion(motion, count: 1))])),
+        ],
+        finalMode: .insert
+    )
+}
+
+@Test(arguments: changeMotionFixtures)
+func changeMotions(_ fixture: KeySequenceFixture) {
+    expectFixture(fixture)
+}
+
+let yankMotionFixtures: [KeySequenceFixture] = operatorMotionKeys.map { key, motion in
+    KeySequenceFixture(
+        "y\(key) → yank over \(motion), Normal 유지",
+        startMode: .normal,
+        steps: [
+            step(.char("y"), .swallow),
+            step(.char(key), .replace([.edit(.yank, .motion(motion, count: 1))])),
+        ],
+        finalMode: .normal
+    )
+}
+
+@Test(arguments: yankMotionFixtures)
+func yankMotions(_ fixture: KeySequenceFixture) {
+    expectFixture(fixture)
+}
+
+// 오퍼레이터 키 반복(cc/yy)은 dd와 같은 줄 단위 범위 — 카운트도 같은 곱 규칙.
+let operatorLineFixtures: [KeySequenceFixture] = [
+    KeySequenceFixture(
+        "cc → 현재 줄 change, Insert 전이 — 이후 키는 Insert 통과",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char("c"), .replace([.edit(.change, .line(count: 1))])),
+            step(.char("w"), .passthrough),
+        ],
+        finalMode: .insert
+    ),
+    KeySequenceFixture(
+        "yy → 현재 줄 yank, Normal 유지 — 이후 j는 단일 모션",
+        startMode: .normal,
+        steps: [
+            step(.char("y"), .swallow),
+            step(.char("y"), .replace([.edit(.yank, .line(count: 1))])),
+            step(.char("j"), .replace([.move(.lineDown)])),
+        ],
+        finalMode: .normal
+    ),
+    KeySequenceFixture(
+        "2cc → 2줄 change (선행 카운트)",
+        startMode: .normal,
+        steps: [
+            step(.char("2"), .swallow),
+            step(.char("c"), .swallow),
+            step(.char("c"), .replace([.edit(.change, .line(count: 2))])),
+        ],
+        finalMode: .insert
+    ),
+    KeySequenceFixture(
+        "c2c → 2줄 change (opCount)",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char("2"), .swallow),
+            step(.char("c"), .replace([.edit(.change, .line(count: 2))])),
+        ],
+        finalMode: .insert
+    ),
+    KeySequenceFixture(
+        "2y3y → 카운트 곱 6줄 yank",
+        startMode: .normal,
+        steps: [
+            step(.char("2"), .swallow),
+            step(.char("y"), .swallow),
+            step(.char("3"), .swallow),
+            step(.char("y"), .replace([.edit(.yank, .line(count: 6))])),
+        ],
+        finalMode: .normal
+    ),
+]
+
+@Test(arguments: operatorLineFixtures)
+func operatorLines(_ fixture: KeySequenceFixture) {
+    expectFixture(fixture)
+}
+
+// 텍스트 오브젝트 조합 — 스코프 접두(i/a) 경로는 오퍼레이터 공용이다.
+let operatorTextObjectFixtures: [KeySequenceFixture] = [
+    KeySequenceFixture(
+        "ciw → change inner word, Insert 전이",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char("i"), .swallow),
+            step(.char("w"), .replace([.edit(.change, .textObject(.word(.inner)))])),
+        ],
+        finalMode: .insert
+    ),
+    KeySequenceFixture(
+        "caw → change around word, Insert 전이",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char("a"), .swallow),
+            step(.char("w"), .replace([.edit(.change, .textObject(.word(.around)))])),
+        ],
+        finalMode: .insert
+    ),
+    KeySequenceFixture(
+        "yiw → yank inner word, Normal 유지",
+        startMode: .normal,
+        steps: [
+            step(.char("y"), .swallow),
+            step(.char("i"), .swallow),
+            step(.char("w"), .replace([.edit(.yank, .textObject(.word(.inner)))])),
+        ],
+        finalMode: .normal
+    ),
+    KeySequenceFixture(
+        "yaw → yank around word, Normal 유지",
+        startMode: .normal,
+        steps: [
+            step(.char("y"), .swallow),
+            step(.char("a"), .swallow),
+            step(.char("w"), .replace([.edit(.yank, .textObject(.word(.around)))])),
+        ],
+        finalMode: .normal
+    ),
+]
+
+@Test(arguments: operatorTextObjectFixtures)
+func operatorTextObjects(_ fixture: KeySequenceFixture) {
+    expectFixture(fixture)
+}
+
+// 혼합 오퍼레이터(dc, yd 등)는 문법에 없다 — pending과 키를 함께 버리는
+// invalid no-op. change가 무효로 끝나면 Insert 전이도 없다.
+private let mixedOperatorPairs: [(Character, Character)] = [
+    ("d", "c"), ("d", "y"),
+    ("c", "d"), ("c", "y"),
+    ("y", "d"), ("y", "c"),
+]
+
+let mixedOperatorFixtures: [KeySequenceFixture] = mixedOperatorPairs.map { first, second in
+    KeySequenceFixture(
+        "\(first)\(second) → no-op (혼합 오퍼레이터) — 이후 w는 단일 모션",
+        startMode: .normal,
+        steps: [
+            step(.char(first), .swallow),
+            step(.char(second), .swallow),
+            step(.char("w"), .replace([.move(.wordForward)])),
+        ],
+        finalMode: .normal
+    )
+}
+
+@Test(arguments: mixedOperatorFixtures)
+func mixedOperators(_ fixture: KeySequenceFixture) {
+    expectFixture(fixture)
+}
+
+// c 뒤 무효·이연 키 핀 — dq/dj/dg 핀(EditFixtures)의 change 대응.
+// cj(linewise)·cg(dgg 문법)는 이후 확장에서 의미가 생기며 이 핀이 갱신된다.
+let changeInvalidFixtures: [KeySequenceFixture] = [
+    KeySequenceFixture(
+        "cq → no-op (무효 키) — 이후 w는 단일 모션, Insert 진입 없음",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char("q"), .swallow),
+            step(.char("w"), .replace([.move(.wordForward)])),
+        ],
+        finalMode: .normal
+    ),
+    KeySequenceFixture(
+        "cj → no-op (linewise-over-motion 이연)",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char("j"), .swallow),
+        ],
+        finalMode: .normal
+    ),
+    KeySequenceFixture(
+        "cg → no-op (g 접두는 오퍼레이터 뒤에 못 온다) — 이후 w는 단일 모션",
+        startMode: .normal,
+        steps: [
+            step(.char("c"), .swallow),
+            step(.char("g"), .swallow),
+            step(.char("w"), .replace([.move(.wordForward)])),
+        ],
+        finalMode: .normal
+    ),
+]
+
+@Test(arguments: changeInvalidFixtures)
+func changeInvalids(_ fixture: KeySequenceFixture) {
+    expectFixture(fixture)
+}


### PR DESCRIPTION
# Summary

엔진 커맨드 문법에 c(change)/y(yank) 오퍼레이터를 일반화합니다. 기존 `d` 하드코딩을 `operatorKeys` 테이블로 교체해 `cc`/`yy`·모션·텍스트 오브젝트 조합이 열리고, change는 완결 시 Insert로 전이합니다. 순수 엔진 타깃(`Packages/VimActionCore`)만 변경 — 엔진 확장 플랜 1/3.

## Change Type

**New feature**

## Details

- `VimAction.Operator`에 `.change`/`.yank` 추가
- `operatorKeys` 테이블 하나로 최상위 진입(d/c/y)과 자기 키 반복 판정(`dd`/`cc`/`yy` = `.line(count:)`)을 일반화 — 혼합(`dc`/`yd` 등)은 화이트리스트 밖 invalid로 자연 낙하
- `complete` 헬퍼로 완결 3지점(줄·모션·텍스트 오브젝트)을 공통화 — `.change`만 완결 시 `mode = .insert` (`a`/`A`의 전이+출력 동시 패턴), `.yank`는 Normal 유지
- 기존 모션 화이트리스트·카운트 곱·클램프·`i`/`a` 스코프 경로는 이미 op-일반화되어 있어 `c$`/`yiw`/`2y3y` 조합이 자동 동작
- `cw` 특례(Vim의 `ce` 동작)는 의도적으로 미구현 — literal 출력, 의미 복원은 어댑터 몫 (플랜 "기록" 단계에서 decisions 문서화 예정)

### 테스트

- 신규 `OperatorFixtures.swift` 34케이스: c/y × 모션 8종 전수, 줄 반복·카운트 곱(`2cc`/`c2c`/`2y3y`), `ciw`/`caw`/`yiw`/`yaw`, 혼합 오퍼레이터 6조합 invalid, `cq`/`cj`/`cg` 이연 핀(linewise 단계에서 갱신 예정)
- 취소 매트릭스(`CancellationFixtures.swift`)에 `c`/`ci` 깊이 추가 — 취소가 change의 Insert 전이를 유발하지 않음을 핀
- `swift test` 전체 GREEN (기존 픽스처 무회귀)

## Breaking Changes

없음 — 소비자는 `VimAction`에 exhaustive switch를 걸지 않는 계약이라 케이스 추가 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)