### PR TITLE
feat(app): Keyboard 모션 실행 계층 — MotionKeyMapper + KeyboardAdapter

### DIFF
--- a/.claude/skills/architecture/references/reentrancy-and-safety.md
+++ b/.claude/skills/architecture/references/reentrancy-and-safety.md
@@ -37,7 +37,7 @@ sequenceDiagram
 
 사용자 노출: 킬 탭이 어느 지점에 설치됐는지(HID / 세션 폴백 / 활성화 실패 / 미설치)는 Settings의 읽기 전용 "Kill Switch" 행과 콤보 안내 각주로 표시한다 — 안전장치가 조용히 부재하는 것이 이 기능의 가장 위험한 실패 모드다. 단축키 커스터마이즈 UI는 아직 없다(고정 콤보).
 
-**과도기 상태 (배선 마일스톤)**: 출력 인프라는 존재하되 **호출자가 없다** — `ActionExecutor`(마커를 찍는 유일한 지점)와 탭측 마커 가드, 폭주 카운터와 보고 훅은 모두 구현·테스트돼 있지만, `VimAction` → CGEvent 시퀀스 매핑이 아직 없어 게시하는 코드도 실패를 보고하는 코드도 없다. 그때까지 엔진의 `.replace` 결정은 실행 없이 삼키고 DEBUG 요약만 로그한다. 릴리스 빌드에선 이 삼킴이 무로그라 사용자에게 "죽은 키"로 보이므로, **디스패처 마일스톤 전 릴리스 배포는 금지**한다 ([20260717_replace-swallow-transitional-rule.md](../../decisions/references/20260717_replace-swallow-transitional-rule.md)).
+**과도기 상태 (배선 마일스톤)**: 출력 계층은 존재하되 **호출자가 없다** — `ActionExecutor`(마커를 찍는 유일한 지점)와 탭측 마커 가드, 폭주 카운터와 보고 훅, 그리고 모션의 `VimAction` → CGEvent 변환(`MotionKeyMapper`·`KeyboardAdapter`)까지 구현·테스트돼 있지만, 탭 콜백이 아직 어댑터를 부르지 않아 실제로 게시하는 코드도 실패를 보고하는 코드도 없다. 그때까지 엔진의 `.replace` 결정은 실행 없이 삼키고 DEBUG 요약만 로그한다. 릴리스 빌드에선 이 삼킴이 무로그라 사용자에게 "죽은 키"로 보이므로, **디스패처 마일스톤 전 릴리스 배포는 금지**한다 ([20260717_replace-swallow-transitional-rule.md](../../decisions/references/20260717_replace-swallow-transitional-rule.md)).
 
 ## 불변식·계약
 

--- a/.claude/skills/plans/SKILL.md
+++ b/.claude/skills/plans/SKILL.md
@@ -50,4 +50,4 @@ description: VimAction 프로젝트의 진행 중 작업 플랜(단기 기억) S
 | Created | Updated | Title | Short Description | Reference |
 |---|---|---|---|---|
 | 2026-07-25 | 2026-07-26 | MVP 1단계 마일스톤 | 실행 계층 구축 순서 M1~M5 (Keyboard 베이스 → AX 확장) — M1 출력 인프라·안전망 → M2 Keyboard 모션 → M3 편집·Visual·요소 리졸버 → M4 프로파일(=MVP 완료선) → M5 AX. **M1 종료·병합 완료**(세션 A 출력 인프라 PR #17 + 세션 B 킬스위치·리뷰 반영 PR #18) + **M2 선행 완료**(ActionExecutor 격리 정리, 경고 기준선 0건), 다음 착수: M2 | [20260725_mvp-milestones.md](references/20260725_mvp-milestones.md) |
-| 2026-07-26 | 2026-07-26 | M2 Keyboard 모션 어댑터 | MVP M2의 상세 플랜 — 설계 확정 완료(결정 3건: 미지원≠실패, 엔진 전 게이트+모드 동결, `Motion → [KeyStroke]` 매핑 계약·근사 3건). 다음 착수: 매퍼+어댑터 구현 | [20260726_m2-keyboard-motion-adapter.md](references/20260726_m2-keyboard-motion-adapter.md) |
+| 2026-07-26 | 2026-07-26 | M2 Keyboard 모션 어댑터 | MVP M2의 상세 플랜 — 설계 확정(결정 3건) + **세션 A 완료**(`MotionKeyMapper`·`KeyboardAdapter`, 호출자 없는 순수 실행 계층). 다음 착수: 세션 B(앱 게이트 + 배선 + 도그푸딩) | [20260726_m2-keyboard-motion-adapter.md](references/20260726_m2-keyboard-motion-adapter.md) |

--- a/.claude/skills/plans/references/20260726_m2-keyboard-motion-adapter.md
+++ b/.claude/skills/plans/references/20260726_m2-keyboard-motion-adapter.md
@@ -12,6 +12,7 @@ Normal 모드의 이동 계열 `VimAction`이 실제 앱에서 합성 CGEvent로
 ## 완료된 것
 
 - [x] **설계 확정** (2026-07-26, 결정 3건 기록): 미지원 액션 = 실패 아님(스킵+DEBUG 로그), 앱 게이트 = 엔진 전 통과 + 모드 동결(disable 초기값 `com.mitchellh.ghostty` 하드코딩), 매핑 계약 = 순수 매퍼 `Motion → [KeyStroke]`(배열 반환이 계약, 근사 3건: w≈e, ^≈0, a/A 자연 수렴). 카운트는 엔진 클램프(9,999) 그대로 — 상한·합치기는 실측 후 판단.
+- [x] **세션 A — 매퍼 + 어댑터** (2026-07-26, TDD): `MotionKeyMapper`(순수, 골든 테이블 14케이스 전수) + `KeyboardAdapter`(`.move`만 실행, 직렬 큐 위 keyDown+keyUp 생성 → `ActionExecutor.post`, 미지원 스킵+DEBUG 요약 1건). 실패는 `execute`의 반환 `Bool` 하나로 접어 호출자가 키 입력당 1회만 보고하게 준비 — `reportExecutionFailure` 호출 배선은 세션 B. `EventTapController` 무변경(런타임 동작 변화 0). 부수: 테스트 타깃의 동명 로컬 픽스처 구조체를 제거하고 프로덕션 `KeyStroke` 재사용.
 
 ## 남은 것
 
@@ -19,13 +20,13 @@ Normal 모드의 이동 계열 `VimAction`이 실제 앱에서 합성 CGEvent로
 
 M2는 **2세션 + 2PR**로 진행한다 — 세션 A는 호출자 없는 순수 실행 계층(런타임 변화 0, M1 세션 A 패턴), 세션 B는 콜백 가드 체인을 건드리는 행동 변화 + 실기기 검증. 도그푸딩發 매핑 조정 diff가 순수 로직 PR에 섞이지 않게 하는 분리다.
 
-- [ ] **세션 A — 매퍼 + 어댑터** (goal 모드, TDD): `MotionKeyMapper`(순수, 골든 테이블 테스트 — 결정 문서의 매핑표가 픽스처) + `KeyboardAdapter`(직렬 큐 위에서 KeyStroke → keyDown+keyUp CGEvent 쌍 생성 → `ActionExecutor.post`, 미지원 액션 스킵+DEBUG 로그, 실패는 키 입력당 1회 접기 — 단 `reportExecutionFailure` 호출 배선은 세션 B). 파일은 앱 타깃. `EventTapController`는 건드리지 않는다.
 - [ ] **세션 B — 게이트 + 배선 + 도그푸딩** (plan 모드 → 구현): 최전면 bundleID 캐시(`@MainActor`, `NSWorkspace` 활성화 알림 구독) → `handleKeyDown` 가드 체인에 게이트 삽입(마커·토글 뒤, 번역 앞) → `.replace` 분기에서 actions를 직렬 큐로 전달. plan 모드에서 확정할 마이크로 결정: 직렬 큐 소유자·수명, 기존 DEBUG 요약 로그 유지 여부, 게이트 캐시 초기값(앱 시작 시 최전면 앱). 구현 후 실기기 도그푸딩: 주력 앱에서 h/j/k/l·w/b/e·0/$/gg/G 동작, Ghostty 완전 통과(Esc 포함), 근사 3건 체감 평가, `100j` 카운트 폭탄 실측 — 문제 발견 시 매핑표만 조정.
 - [ ] **마무리** (세션 B 말미): 릴리스 배포 금지 규칙 해제 여부 판단(모션은 실행되지만 편집은 여전히 죽은 키 — M3까지 유지가 유력), 플랜 갱신·MVP 마일스톤 플랜에 M2 완료 반영.
 
 ## 진행 중 컨텍스트
 
 - 인계 계약 4종(MVP 플랜에서 승계): ① 게시는 반드시 `ActionExecutor.post` ② CGEvent는 post 호출 직렬 큐 위에서 생성 ③ 실패 보고는 `reportExecutionFailure`만 ④ 보고는 원인 키 입력당 최대 1회.
+- 세션 B가 붙일 접점: `KeyboardAdapter.execute(_ actions: [VimAction]) -> Bool`을 직렬 큐 위에서 호출하고, 반환이 `true`일 때만 `reportExecutionFailure()`를 1회 부른다(반환 자체가 이미 키 입력당 1건으로 접혀 있다). 어댑터는 `nonisolated`·`Sendable`이라 큐 클로저로 그대로 캡처된다.
 - 매핑표 전체(키코드·근사 표시 포함)는 [매핑 계약 결정 문서](../../decisions/references/20260726_motion-keystroke-mapping-contract.md)에 있다 — 골든 테스트는 이 표를 그대로 옮긴다.
 - 테스트는 M1 방식 재사용: `ActionExecutor(postEvent:)` 수집기 주입으로 키코드·플래그·마커 검증. CGEvent **생성**은 TCC 불요라 headless 가능.
 - 빌드 경고 기준선 0건, `defaults.bool` 단언 함정(미설정 키도 false) 주의 — MVP 플랜 컨텍스트 참조.

--- a/.claude/skills/plans/references/20260726_m2-keyboard-motion-adapter.md
+++ b/.claude/skills/plans/references/20260726_m2-keyboard-motion-adapter.md
@@ -3,7 +3,7 @@
 <!-- 파일명 규칙: yyyymmdd_<kebab-case-title>.md — 날짜는 플랜 생성일. 이 문서는 살아있는 문서입니다: 진행에 따라 계속 갱신하고, 완료·폐기되면 삭제합니다 (decisions와 정반대). -->
 
 - **생성일**: 2026-07-26
-- **갱신일**: 2026-07-26
+- **갱신일**: 2026-07-26 (PR #20 리뷰 반영)
 
 ## 목표
 
@@ -12,7 +12,7 @@ Normal 모드의 이동 계열 `VimAction`이 실제 앱에서 합성 CGEvent로
 ## 완료된 것
 
 - [x] **설계 확정** (2026-07-26, 결정 3건 기록): 미지원 액션 = 실패 아님(스킵+DEBUG 로그), 앱 게이트 = 엔진 전 통과 + 모드 동결(disable 초기값 `com.mitchellh.ghostty` 하드코딩), 매핑 계약 = 순수 매퍼 `Motion → [KeyStroke]`(배열 반환이 계약, 근사 3건: w≈e, ^≈0, a/A 자연 수렴). 카운트는 엔진 클램프(9,999) 그대로 — 상한·합치기는 실측 후 판단.
-- [x] **세션 A — 매퍼 + 어댑터** (2026-07-26, TDD): `MotionKeyMapper`(순수, 골든 테이블 14케이스 전수) + `KeyboardAdapter`(`.move`만 실행, 직렬 큐 위 keyDown+keyUp 생성 → `ActionExecutor.post`, 미지원 스킵+DEBUG 요약 1건). 실패는 `execute`의 반환 `Bool` 하나로 접어 호출자가 키 입력당 1회만 보고하게 준비 — `reportExecutionFailure` 호출 배선은 세션 B. `EventTapController` 무변경(런타임 동작 변화 0). 부수: 테스트 타깃의 동명 로컬 픽스처 구조체를 제거하고 프로덕션 `KeyStroke` 재사용.
+- [x] **세션 A — 매퍼 + 어댑터** (2026-07-26, TDD): `MotionKeyMapper`(순수, 골든 테이블 14케이스 전수) + `KeyboardAdapter`(`.move`만 실행, 직렬 큐 위 keyDown+keyUp 생성 → `ActionExecutor.post`, 미지원 스킵+DEBUG 요약 1건). `execute`는 값을 돌려주지 않는다 — 리뷰 반영으로 `Bool` 반환 제거(아래 컨텍스트 참조). `EventTapController` 무변경(런타임 동작 변화 0). 부수: 테스트 타깃의 동명 로컬 픽스처 구조체를 제거하고 프로덕션 `KeyStroke` 재사용, `Motion`에 `CaseIterable`(골든 표 완전성 단언용).
 
 ## 남은 것
 
@@ -26,7 +26,8 @@ M2는 **2세션 + 2PR**로 진행한다 — 세션 A는 호출자 없는 순수 
 ## 진행 중 컨텍스트
 
 - 인계 계약 4종(MVP 플랜에서 승계): ① 게시는 반드시 `ActionExecutor.post` ② CGEvent는 post 호출 직렬 큐 위에서 생성 ③ 실패 보고는 `reportExecutionFailure`만 ④ 보고는 원인 키 입력당 최대 1회.
-- 세션 B가 붙일 접점: `KeyboardAdapter.execute(_ actions: [VimAction]) -> Bool`을 직렬 큐 위에서 호출하고, 반환이 `true`일 때만 `reportExecutionFailure()`를 1회 부른다(반환 자체가 이미 키 입력당 1건으로 접혀 있다). 어댑터는 `nonisolated`·`Sendable`이라 큐 클로저로 그대로 캡처된다.
+- 세션 B가 붙일 접점: `KeyboardAdapter.execute(_ actions: [VimAction])`를 직렬 큐 위에서 호출하기만 하면 된다. 어댑터는 `nonisolated`·`Sendable`이라 큐 클로저로 그대로 캡처된다.
+- **실패 보고 배선은 세션 B에도 없다.** 계약 ④(키 입력당 1회)는 유효하지만, Keyboard 게시 경로(`ActionExecutor.post` → `CGEvent.post`)는 오류를 돌려주지 않아 **접을 실패 자체가 없다** — [실패 보고 단위 결정](../../decisions/references/20260726_execution-failure-report-granularity.md)의 "첫 호출자에서의 도달 범위 주의"가 이미 짚은 내용이다. 세션 A는 도달 불가능한 `CGEvent` 생성 실패만 담은 `Bool`을 반환했는데, 리뷰에서 제거했다(항상 통과하는 단언 3건이 딸려 있었다). 실패 신호는 `AXError`를 돌려주는 **M5 AX 어댑터**가 들어온 뒤 실제 실패 형태에 맞춰 만든다.
 - 매핑표 전체(키코드·근사 표시 포함)는 [매핑 계약 결정 문서](../../decisions/references/20260726_motion-keystroke-mapping-contract.md)에 있다 — 골든 테스트는 이 표를 그대로 옮긴다.
 - 테스트는 M1 방식 재사용: `ActionExecutor(postEvent:)` 수집기 주입으로 키코드·플래그·마커 검증. CGEvent **생성**은 TCC 불요라 headless 가능.
 - 빌드 경고 기준선 0건, `defaults.bool` 단언 함정(미설정 키도 false) 주의 — MVP 플랜 컨텍스트 참조.

--- a/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
+++ b/Packages/VimActionCore/Sources/VimEngine/VimAction.swift
@@ -100,7 +100,7 @@ public enum VimAction: Hashable, Sendable {
 
 /// 커서 이동의 종류. 단어 경계·줄 경계의 실제 의미(어디까지가 단어인가 등)는
 /// 어댑터가 정하며, 엔진은 추상 케이스만 낸다.
-public enum Motion: Hashable, Sendable {
+public enum Motion: Hashable, Sendable, CaseIterable {
     case charLeft
     case charRight
     case lineUp

--- a/VimAction/KeyboardAdapter.swift
+++ b/VimAction/KeyboardAdapter.swift
@@ -24,14 +24,8 @@ nonisolated struct KeyboardAdapter: Sendable {
     }
 
     /// 키 입력 1건이 만든 액션 시퀀스를 실행한다.
-    ///
-    /// 반환값은 **실행을 시도했는데 깨진 것이 하나라도 있었는가** — 호출자는 이 한 값으로
-    /// `reportExecutionFailure`를 원인 키 입력당 최대 1회 호출한다 (action별 보고는
-    /// 카운트 반복 출력이 폭주 임계를 즉시 압도하는 오탐이 된다). 미지원 액션 스킵은
-    /// 여기 포함되지 않는다.
-    func execute(_ actions: [VimAction]) -> Bool {
+    func execute(_ actions: [VimAction]) {
         var events: [CGEvent] = []
-        var didFail = false
         #if DEBUG
         var skippedCount = 0
         var firstSkipped: VimAction?
@@ -51,11 +45,7 @@ nonisolated struct KeyboardAdapter: Sendable {
                         keyboardEventSource: nil, virtualKey: stroke.keyCode, keyDown: true),
                     let up = CGEvent(
                         keyboardEventSource: nil, virtualKey: stroke.keyCode, keyDown: false)
-                else {
-                    // 여기까지 왔다면 실행을 시도했는데 깨진 것 — 보고 대상인 진짜 실패다.
-                    didFail = true
-                    continue
-                }
+                else { continue }
                 // 소스가 nil인 이벤트는 flags 기본값이 **실행 시점의 실제 modifier 상태**라,
                 // 대입은 선택이 아니라 필수다 — 사용자가 누르고 있던 키가 새어 들어간다.
                 down.flags = stroke.flags
@@ -76,6 +66,5 @@ nonisolated struct KeyboardAdapter: Sendable {
         #endif
 
         executor.post(events)
-        return didFail
     }
 }

--- a/VimAction/KeyboardAdapter.swift
+++ b/VimAction/KeyboardAdapter.swift
@@ -1,0 +1,78 @@
+//
+//  KeyboardAdapter.swift
+//  VimAction
+//
+
+import CoreGraphics
+import os
+import VimEngine
+
+/// Keyboard 전략의 실행 어댑터 — 엔진이 낸 `VimAction`을 합성 `CGEvent`로 바꿔
+/// `ActionExecutor`로 내보낸다.
+///
+/// **호출은 게시 직렬 큐 위에서** 한다: `CGEvent`는 비-`Sendable`이라 만든 컨텍스트에서
+/// 게시까지 끝내야 하고(격리를 건너는 값이 애초에 없게), 탭 콜백은 경량 불변식에 묶여 있다.
+/// 그래서 타입 단위 `nonisolated`다 — 메인 격리를 가정하지 않는다.
+///
+/// M2 시점의 실행 범위는 `.move`뿐이다. 아직 구현하지 않은 액션은 **실패가 아니다** —
+/// 조용히 스킵하고 DEBUG 로그만 남긴다 (`20260726_unsupported-action-not-failure.md`).
+nonisolated struct KeyboardAdapter: Sendable {
+    private let executor: ActionExecutor
+
+    init(executor: ActionExecutor = ActionExecutor()) {
+        self.executor = executor
+    }
+
+    /// 키 입력 1건이 만든 액션 시퀀스를 실행한다.
+    ///
+    /// 반환값은 **실행을 시도했는데 깨진 것이 하나라도 있었는가** — 호출자는 이 한 값으로
+    /// `reportExecutionFailure`를 원인 키 입력당 최대 1회 호출한다 (action별 보고는
+    /// 카운트 반복 출력이 폭주 임계를 즉시 압도하는 오탐이 된다). 미지원 액션 스킵은
+    /// 여기 포함되지 않는다.
+    func execute(_ actions: [VimAction]) -> Bool {
+        var events: [CGEvent] = []
+        var didFail = false
+        #if DEBUG
+        var skipped: [VimAction] = []
+        #endif
+
+        for action in actions {
+            guard case .move(let motion) = action else {
+                #if DEBUG
+                skipped.append(action)
+                #endif
+                continue
+            }
+            for stroke in MotionKeyMapper.keyStrokes(for: motion) {
+                guard
+                    let down = CGEvent(
+                        keyboardEventSource: nil, virtualKey: stroke.keyCode, keyDown: true),
+                    let up = CGEvent(
+                        keyboardEventSource: nil, virtualKey: stroke.keyCode, keyDown: false)
+                else {
+                    // 여기까지 왔다면 실행을 시도했는데 깨진 것 — 보고 대상인 진짜 실패다.
+                    didFail = true
+                    continue
+                }
+                // 소스가 nil인 이벤트는 flags 기본값이 **실행 시점의 실제 modifier 상태**라,
+                // 대입은 선택이 아니라 필수다 — 사용자가 누르고 있던 키가 새어 들어간다.
+                down.flags = stroke.flags
+                up.flags = stroke.flags
+                events.append(down)
+                events.append(up)
+            }
+        }
+
+        #if DEBUG
+        // 카운트 반복(`100dd` 등)으로 액션이 수천 개일 수 있어 요약 1건으로 접는다.
+        if let first = skipped.first {
+            Logger.eventTap.debug(
+                "미지원 액션 스킵 ×\(skipped.count, privacy: .public): \(String(describing: first), privacy: .public)"
+            )
+        }
+        #endif
+
+        executor.post(events)
+        return didFail
+    }
+}

--- a/VimAction/KeyboardAdapter.swift
+++ b/VimAction/KeyboardAdapter.swift
@@ -33,13 +33,15 @@ nonisolated struct KeyboardAdapter: Sendable {
         var events: [CGEvent] = []
         var didFail = false
         #if DEBUG
-        var skipped: [VimAction] = []
+        var skippedCount = 0
+        var firstSkipped: VimAction?
         #endif
 
         for action in actions {
             guard case .move(let motion) = action else {
                 #if DEBUG
-                skipped.append(action)
+                skippedCount += 1
+                if firstSkipped == nil { firstSkipped = action }
                 #endif
                 continue
             }
@@ -64,10 +66,11 @@ nonisolated struct KeyboardAdapter: Sendable {
         }
 
         #if DEBUG
-        // 카운트 반복(`100dd` 등)으로 액션이 수천 개일 수 있어 요약 1건으로 접는다.
-        if let first = skipped.first {
+        // 카운트 반복(`9999u`, Visual `9999j` 등)으로 액션이 수천 개일 수 있어 요약 1건으로
+        // 접는다. 요약에 쓰는 건 개수와 첫 1개뿐이라 액션 자체를 쌓아 두지 않는다.
+        if let first = firstSkipped {
             Logger.eventTap.debug(
-                "미지원 액션 스킵 ×\(skipped.count, privacy: .public): \(String(describing: first), privacy: .public)"
+                "미지원 액션 스킵 ×\(skippedCount, privacy: .public): \(String(describing: first), privacy: .public)"
             )
         }
         #endif

--- a/VimAction/MotionKeyMapper.swift
+++ b/VimAction/MotionKeyMapper.swift
@@ -1,0 +1,68 @@
+//
+//  MotionKeyMapper.swift
+//  VimAction
+//
+
+import Carbon.HIToolbox
+import CoreGraphics
+import VimEngine
+
+/// 합성할 키 한 타 — `(keyCode, flags)`만 담는 값 타입.
+///
+/// `CGEvent`가 아닌 것이 핵심이다: `CGEvent`는 비-`Sendable`이라 게시 직렬 큐 위에서만
+/// 만들 수 있으므로, 매핑 로직은 이벤트 없이 표현·테스트하고 변환은 어댑터가 큐 위에서 한다.
+nonisolated struct KeyStroke: Equatable, Sendable {
+    let keyCode: CGKeyCode
+    let flags: CGEventFlags
+
+    init(_ keyCode: Int, _ flags: CGEventFlags = []) {
+        self.keyCode = CGKeyCode(keyCode)
+        self.flags = flags
+    }
+}
+
+/// `Motion` → 합성 키스트로크 시퀀스. macOS 텍스트 시스템의 표준 캐럿 이동 단축키로
+/// 매핑하는 순수 함수다 (화살표 키코드는 레이아웃 무관 고정값이라 레이아웃 이슈가 없다).
+///
+/// **반환이 배열인 것이 계약이다** — 모션 1개를 키스트로크 N개 조합으로 실행하는 개선
+/// (예: `w`를 `Opt-→ Opt-→ Opt-←` 3타로)이 이 테이블의 원소 교체만으로 되게 한다.
+/// 어댑터·실행기·테스트는 그대로다.
+///
+/// Keyboard 전략은 캐럿(문자 사이) 모델이라 Vim 커서(문자 위) 개념 3곳은 근사한다:
+/// `wordForward`≈`wordEndForward`, `lineFirstNonBlank`≈`lineStart`, append 전용 모션은
+/// `charRight`·`lineEnd`와 자연 수렴. 정확한 의미는 AX 어댑터의 몫이다
+/// (`20260726_motion-keystroke-mapping-contract.md`).
+nonisolated enum MotionKeyMapper {
+    static func keyStrokes(for motion: Motion) -> [KeyStroke] {
+        switch motion {
+        case .charLeft:
+            return [KeyStroke(kVK_LeftArrow)]
+        case .charRight:
+            return [KeyStroke(kVK_RightArrow)]
+        case .lineUp:
+            return [KeyStroke(kVK_UpArrow)]
+        case .lineDown:
+            return [KeyStroke(kVK_DownArrow)]
+        case .wordForward:
+            return [KeyStroke(kVK_RightArrow, [.maskAlternate])]  // 근사 — e와 동일
+        case .wordBackward:
+            return [KeyStroke(kVK_LeftArrow, [.maskAlternate])]
+        case .wordEndForward:
+            return [KeyStroke(kVK_RightArrow, [.maskAlternate])]
+        case .lineStart:
+            return [KeyStroke(kVK_LeftArrow, [.maskCommand])]
+        case .lineFirstNonBlank:
+            return [KeyStroke(kVK_LeftArrow, [.maskCommand])]  // 근사 — 0과 동일
+        case .lineEnd:
+            return [KeyStroke(kVK_RightArrow, [.maskCommand])]
+        case .documentStart:
+            return [KeyStroke(kVK_UpArrow, [.maskCommand])]
+        case .documentEnd:
+            return [KeyStroke(kVK_DownArrow, [.maskCommand])]
+        case .charRightForAppend:
+            return [KeyStroke(kVK_RightArrow)]
+        case .lineEndForAppend:
+            return [KeyStroke(kVK_RightArrow, [.maskCommand])]
+        }
+    }
+}

--- a/VimActionTests/EventTapDecisionTests.swift
+++ b/VimActionTests/EventTapDecisionTests.swift
@@ -9,17 +9,6 @@ import Testing
 import VimEngine
 @testable import VimAction
 
-/// 합성 keyDown 한 번의 입력 (virtualKey + flags).
-struct KeyStroke: Sendable {
-    var virtualKey: CGKeyCode
-    var flags: CGEventFlags
-
-    init(_ virtualKey: Int, _ flags: CGEventFlags = []) {
-        self.virtualKey = CGKeyCode(virtualKey)
-        self.flags = flags
-    }
-}
-
 /// 키 시퀀스 → 마지막 키의 처리 결과(통과 여부)와 최종 모드 픽스처.
 ///
 /// 엔진은 컨트롤러 내부라 상태를 직접 주입할 수 없다 — Normal 진입도 Esc 이벤트로
@@ -110,7 +99,7 @@ struct EventTapDecisionTests {
             var lastResult: Unmanaged<CGEvent>?
             for stroke in fixture.sequence {
                 let event = try #require(
-                    CGEvent(keyboardEventSource: nil, virtualKey: stroke.virtualKey, keyDown: true),
+                    CGEvent(keyboardEventSource: nil, virtualKey: stroke.keyCode, keyDown: true),
                     "합성 CGEvent 생성 실패: \(fixture.name)"
                 )
                 event.flags = stroke.flags

--- a/VimActionTests/KeyboardAdapterTests.swift
+++ b/VimActionTests/KeyboardAdapterTests.swift
@@ -1,0 +1,128 @@
+//
+//  KeyboardAdapterTests.swift
+//  VimActionTests
+//
+
+import Carbon.HIToolbox
+import CoreGraphics
+import Testing
+import VimEngine
+@testable import VimAction
+
+/// 게시 함수를 가로챈 어댑터 — 실제 키를 테스트 머신에 주입하지 않는다.
+/// CGEvent **생성**은 TCC 권한이 필요 없어 headless로 돈다.
+private func makeAdapter(collecting posted: @escaping @Sendable (CGEvent) -> Void) -> KeyboardAdapter {
+    KeyboardAdapter(executor: ActionExecutor(postEvent: posted))
+}
+
+private func keyCodes(of events: [CGEvent]) -> [Int64] {
+    events.map { $0.getIntegerValueField(.keyboardEventKeycode) }
+}
+
+struct KeyboardAdapterTests {
+    @Test("모션 1개 → keyDown+keyUp 쌍 (순서·키코드·플래그)")
+    func moveProducesDownUpPair() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        let didFail = adapter.execute([.move(.wordBackward)])
+
+        #expect(!didFail)
+        #expect(posted.map(\.type) == [.keyDown, .keyUp])
+        #expect(keyCodes(of: posted) == [Int64(kVK_LeftArrow), Int64(kVK_LeftArrow)])
+        // 플래그는 keyUp에도 실린다 — 앱이 보는 modifier 상태가 쌍 사이에서 흔들리지 않게.
+        #expect(posted.allSatisfy { $0.flags.contains(.maskAlternate) })
+        #expect(posted.allSatisfy { !$0.flags.contains(.maskCommand) })
+    }
+
+    @Test("모디파이어 없는 모션은 수정키를 싣지 않는다")
+    func plainMotionCarriesNoModifiers() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        _ = adapter.execute([.move(.charLeft)])
+
+        #expect(keyCodes(of: posted) == [Int64(kVK_LeftArrow), Int64(kVK_LeftArrow)])
+        #expect(posted.allSatisfy { $0.flags.isDisjoint(with: [.maskAlternate, .maskCommand, .maskControl, .maskShift]) })
+    }
+
+    /// 카운트는 엔진이 반복 액션으로 펼쳐서 준다 — 어댑터는 순서대로 그만큼 낸다.
+    @Test("반복 모션은 순서대로 전부 게시된다")
+    func repeatedMotionsPostInOrder() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        let didFail = adapter.execute([.move(.lineDown), .move(.lineDown), .move(.lineEnd)])
+
+        #expect(!didFail)
+        #expect(posted.count == 6)
+        #expect(
+            keyCodes(of: posted) == [
+                Int64(kVK_DownArrow), Int64(kVK_DownArrow),
+                Int64(kVK_DownArrow), Int64(kVK_DownArrow),
+                Int64(kVK_RightArrow), Int64(kVK_RightArrow),
+            ])
+        #expect(posted.suffix(2).allSatisfy { $0.flags.contains(.maskCommand) })
+    }
+
+    /// 미지원 액션은 **실패가 아니다** — 조용히 스킵한다. 실패로 보고하면 정상 사용의
+    /// `dd` 연타가 폭주 자동 off를 트립하는 오탐이 된다.
+    @Test("미지원 액션은 게시 없이 스킵되고 실패로 보고되지 않는다")
+    func unsupportedActionsAreSkippedNotFailed() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        let didFail = adapter.execute([
+            .edit(.delete, .line(count: 1)),
+            .paste(before: false, count: 1),
+            .beginSelection(linewise: false),
+            .extendSelection(.charRight),
+            .openLine(above: false),
+            .undo,
+            .redo,
+            .scroll(.halfPage, forward: true),
+            .clearSelection,
+            .switchSelectionWise(linewise: true),
+        ])
+
+        #expect(!didFail)
+        #expect(posted.isEmpty)
+    }
+
+    @Test("미지원이 섞여 있어도 모션은 실행된다")
+    func supportedMotionsRunAlongsideUnsupported() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        let didFail = adapter.execute([
+            .edit(.delete, .line(count: 1)),
+            .move(.charRight),
+            .undo,
+        ])
+
+        #expect(!didFail)
+        #expect(keyCodes(of: posted) == [Int64(kVK_RightArrow), Int64(kVK_RightArrow)])
+    }
+
+    @Test("빈 액션 시퀀스는 아무것도 게시하지 않는다")
+    func emptyActionsPostNothing() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        #expect(!adapter.execute([]))
+        #expect(posted.isEmpty)
+    }
+
+    /// 마커 불변식 — 어댑터가 내는 이벤트는 전부 `ActionExecutor`를 거치므로 마킹돼 있다.
+    /// 마킹되지 않은 합성 이벤트는 탭이 재해석해 무한 루프가 된다.
+    @Test("게시된 모든 이벤트에 합성 마커가 찍혀 있다")
+    func everyPostedEventIsMarked() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        _ = adapter.execute([.move(.documentEnd), .move(.charLeft)])
+
+        #expect(posted.count == 4)
+        #expect(posted.allSatisfy { SyntheticEventMarker.isMarked($0) })
+    }
+}

--- a/VimActionTests/KeyboardAdapterTests.swift
+++ b/VimActionTests/KeyboardAdapterTests.swift
@@ -25,9 +25,8 @@ struct KeyboardAdapterTests {
         nonisolated(unsafe) var posted: [CGEvent] = []
         let adapter = makeAdapter { posted.append($0) }
 
-        let didFail = adapter.execute([.move(.wordBackward)])
+        adapter.execute([.move(.wordBackward)])
 
-        #expect(!didFail)
         #expect(posted.map(\.type) == [.keyDown, .keyUp])
         #expect(keyCodes(of: posted) == [Int64(kVK_LeftArrow), Int64(kVK_LeftArrow)])
         // 플래그는 keyUp에도 실린다 — 앱이 보는 modifier 상태가 쌍 사이에서 흔들리지 않게.
@@ -40,7 +39,7 @@ struct KeyboardAdapterTests {
         nonisolated(unsafe) var posted: [CGEvent] = []
         let adapter = makeAdapter { posted.append($0) }
 
-        _ = adapter.execute([.move(.charLeft)])
+        adapter.execute([.move(.charLeft)])
 
         #expect(keyCodes(of: posted) == [Int64(kVK_LeftArrow), Int64(kVK_LeftArrow)])
         #expect(posted.allSatisfy { $0.flags.isDisjoint(with: [.maskAlternate, .maskCommand, .maskControl, .maskShift]) })
@@ -52,9 +51,8 @@ struct KeyboardAdapterTests {
         nonisolated(unsafe) var posted: [CGEvent] = []
         let adapter = makeAdapter { posted.append($0) }
 
-        let didFail = adapter.execute([.move(.lineDown), .move(.lineDown), .move(.lineEnd)])
+        adapter.execute([.move(.lineDown), .move(.lineDown), .move(.lineEnd)])
 
-        #expect(!didFail)
         #expect(posted.count == 6)
         #expect(
             keyCodes(of: posted) == [
@@ -67,12 +65,12 @@ struct KeyboardAdapterTests {
 
     /// 미지원 액션은 **실패가 아니다** — 조용히 스킵한다. 실패로 보고하면 정상 사용의
     /// `dd` 연타가 폭주 자동 off를 트립하는 오탐이 된다.
-    @Test("미지원 액션은 게시 없이 스킵되고 실패로 보고되지 않는다")
-    func unsupportedActionsAreSkippedNotFailed() {
+    @Test("미지원 액션은 게시 없이 스킵된다")
+    func unsupportedActionsAreSkipped() {
         nonisolated(unsafe) var posted: [CGEvent] = []
         let adapter = makeAdapter { posted.append($0) }
 
-        let didFail = adapter.execute([
+        adapter.execute([
             .edit(.delete, .line(count: 1)),
             .paste(before: false, count: 1),
             .beginSelection(linewise: false),
@@ -85,7 +83,6 @@ struct KeyboardAdapterTests {
             .switchSelectionWise(linewise: true),
         ])
 
-        #expect(!didFail)
         #expect(posted.isEmpty)
     }
 
@@ -94,13 +91,12 @@ struct KeyboardAdapterTests {
         nonisolated(unsafe) var posted: [CGEvent] = []
         let adapter = makeAdapter { posted.append($0) }
 
-        let didFail = adapter.execute([
+        adapter.execute([
             .edit(.delete, .line(count: 1)),
             .move(.charRight),
             .undo,
         ])
 
-        #expect(!didFail)
         #expect(keyCodes(of: posted) == [Int64(kVK_RightArrow), Int64(kVK_RightArrow)])
     }
 
@@ -109,7 +105,8 @@ struct KeyboardAdapterTests {
         nonisolated(unsafe) var posted: [CGEvent] = []
         let adapter = makeAdapter { posted.append($0) }
 
-        #expect(!adapter.execute([]))
+        adapter.execute([])
+
         #expect(posted.isEmpty)
     }
 
@@ -120,7 +117,7 @@ struct KeyboardAdapterTests {
         nonisolated(unsafe) var posted: [CGEvent] = []
         let adapter = makeAdapter { posted.append($0) }
 
-        _ = adapter.execute([.move(.documentEnd), .move(.charLeft)])
+        adapter.execute([.move(.documentEnd), .move(.charLeft)])
 
         #expect(posted.count == 4)
         #expect(posted.allSatisfy { SyntheticEventMarker.isMarked($0) })

--- a/VimActionTests/MotionKeyMapperTests.swift
+++ b/VimActionTests/MotionKeyMapperTests.swift
@@ -1,0 +1,69 @@
+//
+//  MotionKeyMapperTests.swift
+//  VimActionTests
+//
+
+import Carbon.HIToolbox
+import CoreGraphics
+import Testing
+import VimEngine
+@testable import VimAction
+
+/// 매핑 계약 결정 문서(`20260726_motion-keystroke-mapping-contract.md`)의 매핑표 한 행.
+/// **이 픽스처가 곧 계약이다** — 표가 바뀌면 여기가 먼저 바뀐다.
+struct MotionMappingFixture: Sendable, CustomTestStringConvertible {
+    var motion: Motion
+    var expected: [KeyStroke]
+
+    init(_ motion: Motion, _ expected: [KeyStroke]) {
+        self.motion = motion
+        self.expected = expected
+    }
+
+    var testDescription: String { "\(motion)" }
+}
+
+/// 매핑표 전체(근사 3건 포함). 화살표 키코드는 레이아웃 무관 고정값이라
+/// QWERTY 조건이 필요 없다.
+let motionMappingFixtures: [MotionMappingFixture] = [
+    .init(.charLeft, [KeyStroke(kVK_LeftArrow)]),
+    .init(.charRight, [KeyStroke(kVK_RightArrow)]),
+    .init(.lineUp, [KeyStroke(kVK_UpArrow)]),
+    .init(.lineDown, [KeyStroke(kVK_DownArrow)]),
+    // 근사 — "다음 단어 시작"이 macOS에 없어 e와 동일 취급.
+    .init(.wordForward, [KeyStroke(kVK_RightArrow, [.maskAlternate])]),
+    .init(.wordBackward, [KeyStroke(kVK_LeftArrow, [.maskAlternate])]),
+    .init(.wordEndForward, [KeyStroke(kVK_RightArrow, [.maskAlternate])]),
+    .init(.lineStart, [KeyStroke(kVK_LeftArrow, [.maskCommand])]),
+    // 근사 — 첫 비공백 개념이 macOS에 없어 0과 동일 취급.
+    .init(.lineFirstNonBlank, [KeyStroke(kVK_LeftArrow, [.maskCommand])]),
+    .init(.lineEnd, [KeyStroke(kVK_RightArrow, [.maskCommand])]),
+    .init(.documentStart, [KeyStroke(kVK_UpArrow, [.maskCommand])]),
+    .init(.documentEnd, [KeyStroke(kVK_DownArrow, [.maskCommand])]),
+    // 캐럿 모델에서 l·$와의 구분이 자연 소멸 — 케이스는 AX 어댑터용으로 유지된다.
+    .init(.charRightForAppend, [KeyStroke(kVK_RightArrow)]),
+    .init(.lineEndForAppend, [KeyStroke(kVK_RightArrow, [.maskCommand])]),
+]
+
+struct MotionKeyMapperTests {
+    @Test("매핑표 골든 — 모션이 계약대로 키스트로크가 된다", arguments: motionMappingFixtures)
+    func mapsMotionAsContracted(_ fixture: MotionMappingFixture) {
+        #expect(MotionKeyMapper.keyStrokes(for: fixture.motion) == fixture.expected, "\(fixture.motion)")
+    }
+
+    /// 매퍼의 switch가 컴파일러 강제로 전 케이스를 덮으므로, 여기서는 **픽스처 쪽**이
+    /// 뒤처지지 않는지를 지킨다 — Motion에 케이스가 늘면 매퍼는 컴파일 에러로,
+    /// 골든 표는 이 개수 단언으로 드러난다.
+    @Test("매핑표가 Motion 전 케이스(14개)를 중복 없이 덮는다")
+    func goldenTableCoversEveryMotion() {
+        #expect(motionMappingFixtures.count == 14)
+        #expect(Set(motionMappingFixtures.map(\.motion)).count == motionMappingFixtures.count)
+    }
+
+    /// 모션은 반드시 실행 가능한 형태로 매핑된다 — 빈 배열은 "조용히 아무것도 안 함"이라
+    /// 미지원 스킵과 구분되지 않는다.
+    @Test("어떤 모션도 빈 시퀀스로 매핑되지 않는다", arguments: motionMappingFixtures)
+    func neverMapsToEmptySequence(_ fixture: MotionMappingFixture) {
+        #expect(!MotionKeyMapper.keyStrokes(for: fixture.motion).isEmpty)
+    }
+}

--- a/VimActionTests/MotionKeyMapperTests.swift
+++ b/VimActionTests/MotionKeyMapperTests.swift
@@ -53,11 +53,12 @@ struct MotionKeyMapperTests {
 
     /// 매퍼의 switch가 컴파일러 강제로 전 케이스를 덮으므로, 여기서는 **픽스처 쪽**이
     /// 뒤처지지 않는지를 지킨다 — Motion에 케이스가 늘면 매퍼는 컴파일 에러로,
-    /// 골든 표는 이 개수 단언으로 드러난다.
-    @Test("매핑표가 Motion 전 케이스(14개)를 중복 없이 덮는다")
+    /// 골든 표는 `allCases` 대조로 드러난다.
+    @Test("매핑표가 Motion 전 케이스를 중복 없이 덮는다")
     func goldenTableCoversEveryMotion() {
-        #expect(motionMappingFixtures.count == 14)
-        #expect(Set(motionMappingFixtures.map(\.motion)).count == motionMappingFixtures.count)
+        let covered = Set(motionMappingFixtures.map(\.motion))
+        #expect(covered == Set(Motion.allCases))
+        #expect(covered.count == motionMappingFixtures.count)
     }
 
     /// 모션은 반드시 실행 가능한 형태로 매핑된다 — 빈 배열은 "조용히 아무것도 안 함"이라


### PR DESCRIPTION
# 요약

M2 세션 A — 엔진이 낸 모션 `VimAction`을 합성 `CGEvent`로 바꾸는 **실행 계층**(매퍼 + 어댑터)을 TDD로 추가한다. 아직 **호출자가 없다**: 탭 콜백 배선과 앱 게이트는 세션 B의 몫이라 런타임 동작 변화는 0이고 `EventTapController` diff도 0이다.

## 왜 세션 A/B로 쪼갰나

M2는 2세션·2PR이다. 세션 A는 콜백 가드 체인을 건드리지 않는 순수 실행 계층, 세션 B는 행동 변화(게이트 + 배선) + 실기기 도그푸딩. 도그푸딩에서 나올 **매핑 조정 diff가 순수 로직 PR에 섞이지 않게** 하는 분리다.

## 무엇을

### `MotionKeyMapper` — 순수 `Motion → [KeyStroke]`

`KeyStroke`는 `(keyCode, flags)`만 담는 값 타입이다. `CGEvent`가 아닌 것이 핵심 — `CGEvent`는 비-`Sendable`이라 게시 직렬 큐 위에서만 만들 수 있으므로, 매핑 로직은 이벤트 없이 표현하고 headless로 골든 테스트한다.

**반환이 배열인 것이 계약**이다. 모션 1개를 N타 조합으로 개선하는 일(예: `w`를 `Opt-→ Opt-→ Opt-←` 3타로)이 테이블 원소 교체만으로 끝나고 어댑터·실행기·테스트는 그대로다.

| Motion | 합성 키 | 성격 |
|---|---|---|
| charLeft / charRight / lineUp / lineDown | ← / → / ↑ / ↓ | 정확 |
| wordBackward / wordEndForward | Opt-← / Opt-→ | 정확 |
| **wordForward** | **Opt-→** | **근사 — e와 동일 취급** |
| lineStart / lineEnd | Cmd-← / Cmd-→ | 정확 |
| **lineFirstNonBlank** | **Cmd-←** | **근사 — 0과 동일 취급** |
| documentStart / documentEnd | Cmd-↑ / Cmd-↓ | 정확 |
| charRightForAppend / lineEndForAppend | → / Cmd-→ | 캐럿 모델에서 l·$와 자연 수렴 |

근사 3건은 원리적이다: Keyboard 전략은 캐럿(문자 사이) 모델이라 Vim 커서(문자 위) 개념을 정확히 재현할 수 없다 — 정확한 의미는 M5 AX 어댑터의 몫이다. 화살표 키코드(123~126)는 레이아웃 무관 고정값이라 레이아웃 이슈가 없다.

### `KeyboardAdapter` — `[VimAction]` → 게시

```mermaid
flowchart LR
    A["[VimAction]"] --> B{"case .move?"}
    B -->|아니오| S["스킵 + DEBUG 요약 1건<br/>(실패 아님)"]
    B -->|예| M[MotionKeyMapper]
    M --> E["KeyStroke → keyDown+keyUp<br/>CGEvent 쌍 (직렬 큐 위)"]
    E --> X["ActionExecutor.post<br/>= 마커 찍는 유일한 지점"]
```

- **타입 단위 `nonisolated` + `Sendable`** — 호출은 게시 직렬 큐 위에서 한다. `CGEvent`는 만든 컨텍스트에서 게시까지 끝내야 하고(격리를 건너는 값이 애초에 없게), 탭 콜백은 경량 불변식에 묶여 있다.
- **미지원 액션은 실패가 아니다** — `edit`/`paste`/`beginSelection` 등은 조용히 스킵하고 DEBUG 로그만 남긴다. 실패로 보고하면 정상 사용의 `dd` 연타가 폭주 자동 off를 트립하는 오탐이 된다. 로그는 카운트 반복(`100dd`)을 감안해 **요약 1건으로 접는다**.
- **실패 신호는 두지 않는다** — `execute`는 값을 돌려주지 않는다. 실패 보고 단위 결정이 이미 짚었듯 Keyboard 게시 경로(`ActionExecutor.post` → `CGEvent.post`)는 **오류를 돌려주지 않아** 접을 실패 자체가 없다(화살표 게시는 앱이 무시하든 말든 성공한다). 실패 채널은 `AXError`를 돌려주는 M5 AX 어댑터가 들어올 때 실제 실패 형태에 맞춰 만든다. 키 입력당 1회 접기 계약은 그대로 유효하며, 그때 지킨다.
- `flags`는 keyDown·keyUp 양쪽에 명시 대입한다 — 소스가 `nil`인 이벤트는 flags 기본값이 **실행 시점의 실제 modifier 상태**라, 대입을 빼면 사용자가 누르고 있던 키가 새어 든다.

## 테스트 (RED → GREEN 확인)

게시 함수를 주입해 실제 키를 머신에 주입하지 않는다(M1 방식 재사용). CGEvent **생성**은 TCC 불요라 headless로 돈다.

| 테스트 | 검증 |
|---|---|
| `MotionKeyMapperTests` 골든 | 매핑표 **14케이스 전수** — 결정 문서 표를 그대로 옮긴 픽스처 |
| 〃 커버리지·비공백 | 픽스처가 `Motion.allCases`를 중복 없이 덮는가, 빈 시퀀스로 매핑되는 모션이 없는가 |
| `KeyboardAdapterTests` 변환 | keyDown+keyUp 순서·키코드·플래그, 수정키 없는 모션에 수정키가 안 붙는가 |
| 〃 반복 | 카운트로 펼쳐진 액션이 순서대로 전부 게시되는가 |
| 〃 미지원 | 미지원 10종 → **게시 0건**, 모션과 섞여도 모션만 실행 |
| 〃 마커 불변식 | 게시된 모든 이벤트에 합성 마커가 찍혀 있는가 |

매퍼의 `switch`는 컴파일러가 전 케이스를 강제하므로, `Motion`에 케이스가 늘면 매퍼는 컴파일 에러로 / 골든 표는 `Set(Motion.allCases)` 대조로 드러난다. 픽스처 1건을 일시 제거해 실제로 빨간불이 뜨는 것을 확인했다.

## 부수 변경

- `EventTapDecisionTests`의 로컬 픽스처 구조체 `KeyStroke`를 제거하고 새 프로덕션 `KeyStroke`를 재사용한다 — 같은 이름·같은 모양이라 두면 테스트 모듈 쪽이 프로덕션 타입을 가려 새 테스트가 매번 `VimAction.KeyStroke`로 한정해야 한다. 내 변경이 만든 충돌이라 여기서 정리했다(diff는 struct 삭제 + `virtualKey` → `keyCode` 1줄).
- `Motion`에 `CaseIterable` 추가 (엔진, 1단어) — 위 완전성 단언이 개수 리터럴이 아니라 실제 케이스 집합을 대조하게 하는 데 필요하다. 전 케이스가 연관값이 없어 합성된다.

## 검증

| 게이트 | 결과 |
|---|---|
| 매퍼 골든 테스트 | GREEN (14케이스) |
| 어댑터 테스트 | GREEN (7건) |
| `VimActionTests` 전체 | GREEN |
| 앱 빌드(CI 동일, 서명 없음) | **경고 0건** — 기준선 유지 |
| `EventTapController` diff | **0줄** |

테스트 타깃에는 pre-existing 경고 1건(`SafetyToggleTests.swift:85`, `try` 불필요)이 있는데, 이 브랜치를 stash한 상태에서 재현해 **main에도 동일하게 있음**을 확인했다 — 이 PR과 무관하며 손대지 않았다.

## 다음 (세션 B, 이 PR 아님)

최전면 bundleID 캐시(`@MainActor` + `NSWorkspace` 알림) → `handleKeyDown` 가드 체인에 앱 게이트 삽입(마커·토글 뒤, 번역 앞) → `.replace` 분기에서 직렬 큐로 `execute` 호출 → 실기기 도그푸딩(근사 3건 체감, `100j` 카운트 폭탄 실측). 실패 보고 배선은 세션 B에도 없다 — 위 "실패 신호는 두지 않는다" 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
