### PR TITLE
FEAT(release): tag push release 파이프라인 — 빌드·서명·공증·DMG·appcast·업로드

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+# 릴리스 파이프라인 — tag(v*) push 트리거 (20260810_tag-push-release-pipeline).
+#
+# 흐름: 빌드(Developer ID 서명, 1단계에서 확정한 오버라이드 그대로) → DMG 패키징(create-dmg)
+# → 공증(notarytool, ASC API 키) + 스테이플 → generate_appcast(EdDSA 서명) → GitHub Release 업로드.
+#
+# 버전은 tag에서 파생한다: v1.2.3 → MARKETING_VERSION=1.2.3, CURRENT_PROJECT_VERSION=1.2.3
+# (CFBundleVersion이 Sparkle의 비교 대상 sparkle:version이 된다 — semver 증가가 곧 단조 증가).
+#
+# 필요한 GH Secrets 4종:
+#   MACOS_CERT_P12          — Developer ID Application 인증서+개인키 p12의 base64
+#   MACOS_CERT_PASSWORD     — 위 p12의 암호
+#   ASC_API_KEY_P8          — App Store Connect API 키(.p8) 내용 (공증용)
+#   SPARKLE_ED_PRIVATE_KEY  — Sparkle EdDSA 개인키 (generate_keys -x 출력)
+#
+# 주의: appcast는 `releases/latest/download/appcast.xml` 고정 URL로 소비되므로
+# 정식 릴리스만 non-prerelease로 발행해야 한다 (20260810_appcast-hosting-github-releases).
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+  # 앱이 링크하는 Sparkle 버전(Package.resolved)과 맞춘다 — 의존성 버전을 올리면 여기도 함께.
+  SPARKLE_VERSION: 2.9.5
+
+jobs:
+  release:
+    name: Build, notarize, and publish
+    runs-on: macos-26
+    timeout-minutes: 120 # 공증 대기 포함 (첫 제출 ~50분 실측)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      # 임시 키체인에만 인증서를 넣는다 — 러너 login 키체인 오염 방지, 종료 시 삭제.
+      - name: Import signing certificate
+        env:
+          CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/release.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "$CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          rm "$RUNNER_TEMP/cert.p12"
+          # codesign이 UI 프롬프트 없이 키를 쓸 수 있어야 한다 (headless 러너).
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+      # 1단계에서 확정한 서명 오버라이드 그대로 (CLAUDE.md·플랜 참고).
+      # CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO 필수 — 기본값이 get-task-allow를 주입해 공증 거부.
+      - name: Build Release (Developer ID, Hardened Runtime)
+        run: >
+          xcodebuild build
+          -project VimAction.xcodeproj
+          -scheme VimAction
+          -configuration Release
+          -destination 'platform=macOS'
+          -derivedDataPath build
+          CODE_SIGN_STYLE=Manual
+          DEVELOPMENT_TEAM=X6DU3VVLRZ
+          CODE_SIGN_IDENTITY="Developer ID Application"
+          ENABLE_HARDENED_RUNTIME=YES
+          CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO
+          OTHER_CODE_SIGN_FLAGS=--timestamp
+          MARKETING_VERSION="$VERSION"
+          CURRENT_PROJECT_VERSION="$VERSION"
+
+      - name: Package DMG
+        run: |
+          brew install create-dmg
+          STAGE="$RUNNER_TEMP/dmg-root"
+          mkdir -p "$STAGE" dist
+          cp -R "build/Build/Products/Release/VimAction.app" "$STAGE/"
+          # create-dmg는 Finder AppleScript로 레이아웃을 잡아 headless 러너에서 간헐 실패한다 — 재시도.
+          for attempt in 1 2 3; do
+            if create-dmg \
+              --volname "VimAction" \
+              --window-size 540 380 \
+              --icon-size 128 \
+              --icon "VimAction.app" 140 180 \
+              --hide-extension "VimAction.app" \
+              --app-drop-link 400 180 \
+              "dist/VimAction-$VERSION.dmg" \
+              "$STAGE"; then
+              break
+            fi
+            rm -f "dist/VimAction-$VERSION.dmg"
+            if [ "$attempt" = 3 ]; then exit 1; fi
+            sleep 10
+          done
+          codesign --force --sign "Developer ID Application" --timestamp \
+            "dist/VimAction-$VERSION.dmg"
+
+      # DMG를 공증하면 내용물(.app)까지 티켓이 발급된다. 스테이플은 DMG에.
+      - name: Notarize and staple
+        env:
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          KEY_FILE="$RUNNER_TEMP/AuthKey_J25P43B5G4.p8"
+          printf '%s\n' "$ASC_API_KEY_P8" > "$KEY_FILE"
+          xcrun notarytool submit "dist/VimAction-$VERSION.dmg" \
+            --key "$KEY_FILE" \
+            --key-id J25P43B5G4 \
+            --issuer 4c66c8b6-9bec-4f18-b220-a53d27eeac23 \
+            --wait
+          rm "$KEY_FILE"
+          xcrun stapler staple "dist/VimAction-$VERSION.dmg"
+          spctl --assess --type open --context context:primary-signature \
+            "dist/VimAction-$VERSION.dmg"
+
+      # 도구는 앱이 링크하는 것과 같은 버전의 Sparkle 배포 tarball에서 가져온다.
+      - name: Generate appcast
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/sparkle.tar.xz" \
+            "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz"
+          mkdir -p "$RUNNER_TEMP/sparkle"
+          tar -xJf "$RUNNER_TEMP/sparkle.tar.xz" -C "$RUNNER_TEMP/sparkle"
+          KEY_FILE="$RUNNER_TEMP/eddsa_private_key"
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEY_FILE"
+          "$RUNNER_TEMP/sparkle/bin/generate_appcast" \
+            --ed-key-file "$KEY_FILE" \
+            --download-url-prefix "https://github.com/pilyang/vim-action/releases/download/$GITHUB_REF_NAME/" \
+            -o dist/appcast.xml \
+            dist
+          rm "$KEY_FILE"
+          cat dist/appcast.xml
+
+      # non-prerelease로 발행해야 releases/latest가 이 릴리스를 가리킨다.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            "dist/VimAction-$VERSION.dmg" \
+            "dist/appcast.xml" \
+            --verify-tag \
+            --title "VimAction $VERSION" \
+            --generate-notes
+
+      - name: Clean up keychain
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/release.keychain-db" || true
+          security list-keychains -d user -s login.keychain-db


### PR DESCRIPTION
## 요약

배포 준비 3단계 — **`v*` tag push 한 번으로 서명·공증된 DMG와 Sparkle appcast가 GitHub Release로 발행**되는 파이프라인. 앱 코드 무변경, `.github/workflows/release.yml` 신설(기존 `ci.yml` 무변경).

플로우: 빌드(Developer ID·Hardened Runtime, 1단계 확정 오버라이드 그대로) → create-dmg 패키징(+DMG 서명) → `notarytool` 공증+스테이플(DMG 티켓이 내용물 포함) → `generate_appcast`(EdDSA 서명) → non-prerelease Release 업로드(DMG + appcast.xml).

## 설계 포인트

- **버전은 tag 파생**: `vX.Y.Z` → `MARKETING_VERSION` = `CURRENT_PROJECT_VERSION` = `X.Y.Z`. `CFBundleVersion`이 Sparkle 비교 대상이라 semver 증가가 곧 단조 증가 — 별도 빌드 번호 체계 없음
- **appcast 도구는 앱이 링크한 것과 같은 2.9.5 tarball**에서 — Sparkle 의존성 bump 시 워크플로우 `SPARKLE_VERSION` 동기화 필요 (주석 명시)
- **GH Secrets 4종** (등록 완료): `MACOS_CERT_P12`/`MACOS_CERT_PASSWORD`, `ASC_API_KEY_P8`, `SPARKLE_ED_PRIVATE_KEY` — 전부 임시 키체인/임시 파일로만 다루고 종료 시 삭제
- create-dmg의 headless 러너 간헐 실패는 3회 재시도로 흡수
- **non-prerelease만 발행** — `releases/latest/download/appcast.xml` 고정 URL이 정식 릴리스만 가리키는 제약 반영

## 검증

- actionlint(shellcheck 포함) 통과
- **실주행 검증은 머지 후 `v0.1.0` 태그로** — 첫 릴리스가 곧 파이프라인의 end-to-end 테스트입니다 (tag 트리거라 PR CI에서는 실행되지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
