### PR TITLE
FIX(release): Sparkle 중첩 실행물 재서명 — 공증 Invalid 해소

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,24 @@ jobs:
           MARKETING_VERSION="$VERSION"
           CURRENT_PROJECT_VERSION="$VERSION"
 
+      # SPM의 Sparkle 아티팩트는 중첩 실행물(XPC 2종·Autoupdate·Updater.app)이 adhoc 서명이고
+      # Xcode 임베드가 재서명하지 않아 공증이 거부된다(v0.1.0 첫 제출 Invalid 실측) —
+      # Sparkle 공식 custom signing 순서대로 안쪽부터 재서명하고 마지막에 앱 씰을 다시 만든다.
+      # Downloader.xpc만 --preserve-metadata=entitlements — 샌드박스 엔타이틀먼트를 지닌 유일한 컴포넌트.
+      - name: Re-sign Sparkle nested components
+        run: |
+          APP="build/Build/Products/Release/VimAction.app"
+          SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
+          ID="Developer ID Application"
+          codesign -f -s "$ID" -o runtime --timestamp --preserve-metadata=entitlements \
+            "$SPARKLE/Versions/B/XPCServices/Downloader.xpc"
+          codesign -f -s "$ID" -o runtime --timestamp "$SPARKLE/Versions/B/XPCServices/Installer.xpc"
+          codesign -f -s "$ID" -o runtime --timestamp "$SPARKLE/Versions/B/Autoupdate"
+          codesign -f -s "$ID" -o runtime --timestamp "$SPARKLE/Versions/B/Updater.app"
+          codesign -f -s "$ID" -o runtime --timestamp "$SPARKLE"
+          codesign -f -s "$ID" -o runtime --timestamp "$APP"
+          codesign --verify --deep --strict "$APP"
+
       - name: Package DMG
         run: |
           brew install create-dmg


### PR DESCRIPTION
## 요약

v0.1.0 첫 공증이 **Invalid**로 거부된 원인 수정. SPM으로 임베드된 `Sparkle.framework`의 중첩 실행물 4종(`Downloader.xpc`, `Installer.xpc`, `Autoupdate`, `Updater.app`)이 **adhoc 서명 + 타임스탬프 부재** 상태였고(아티팩트 배포 상태 그대로 — Xcode 임베드는 재서명하지 않음), Apple notary가 16건의 에러로 거부했다.

## 수정

빌드와 DMG 패키징 사이에 **재서명 스텝 추가** — Sparkle 공식 custom signing 순서 그대로 안쪽부터:

1. `Downloader.xpc` (`--preserve-metadata=entitlements` — 샌드박스 엔타이틀먼트를 지닌 유일한 컴포넌트) → `Installer.xpc` → `Autoupdate` → `Updater.app`
2. `Sparkle.framework` 재서명
3. 앱 번들 씰 재생성 + `codesign --verify --deep --strict`

전부 `Developer ID Application` + `-o runtime` + `--timestamp`.

## 검증

- **로컬 실증: 같은 절차를 적용한 재서명본을 `notarytool`로 제출해 Apple `Accepted` 확인** (submission `c5a2cb5f`)
- actionlint(shellcheck 포함) 통과
- 머지 후 v0.1.0 태그를 새 main으로 재발행해 파이프라인 재주행 (기존 태그는 릴리스 미발행 상태라 이동 무해)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
