### PR TITLE
fix(adapter): pace single-chunk edit groups so operators land on settled selections

### DIFF
--- a/.claude/skills/architecture/references/keyboard-adapter.md
+++ b/.claude/skills/architecture/references/keyboard-adapter.md
@@ -1,6 +1,6 @@
 # Keyboard 어댑터
 
-- **Last updated**: 2026-08-20 (문서 분할 — [strategy-dispatch.md](strategy-dispatch.md)에서 이관 + 심볼 표기 정정: `pasteStrokeGroups` 실명, 설정 어휘 `open_line`)
+- **Last updated**: 2026-08-31 (편집 그룹 페이싱 — 단일 청크 한정 `editGroupPaced` 추가)
 
 ## 현재 구조
 
@@ -40,6 +40,8 @@
 ### 편집 매퍼 — `EditKeyMapper`
 
 `(Operator, TextRange, ElementFamily, ResolvedProfile, FocusedText?) → [KeyStroke]?`. 모든 편집이 한 형태다: **범위를 Shift+모션으로 선택한 뒤 오퍼레이터 1타**(delete·change = `Cmd-X`, yank = `Cmd-C` + `←` collapse). 선택 스트로크는 모션 매핑 결과에 `.maskShift`를 얹어 만들므로 다타 조합도 그대로 성립하고, 모션별 특례는 `cw`→`ce` 하나뿐이다. linewise 반올림은 오퍼레이터별(delete/yank는 개행 포함, change는 줄 유지), 문서 끝에서는 빈 줄 1개가 남는다. `iw`의 무상태 시퀀스는 3타(`Opt-→,Opt-←` 후 `Shift-Opt-→`)이며, 읽기가 성공하면 아래 정확화 표가 갈라내고 남는 무상태 엣지는 2자 이상의 공백·구두점 런뿐이다. 수용 엣지: Notion의 `Shift-Cmd-↑/↓` 블록 이동 충돌(M4 프로파일 몫 — [20260727_notion-cmd-shift-vertical-conflict.md](../../decisions/references/20260727_notion-cmd-shift-vertical-conflict.md)), 소프트 랩 문단의 시각 줄 linewise(창 읽기로 해소 불가 — [20260803_soft-wrap-linewise-not-resolved-by-window-read.md](../../decisions/references/20260803_soft-wrap-linewise-not-resolved-by-window-read.md)). 문서 경계 포화 엣지 5종은 정확화 표로 전부 해소됐다. ([20260727_edit-keystroke-mapping-contract.md](../../decisions/references/20260727_edit-keystroke-mapping-contract.md), [20260727_linewise-newline-rounding.md](../../decisions/references/20260727_linewise-newline-rounding.md), [20260727_yank-collapse-to-range-start.md](../../decisions/references/20260727_yank-collapse-to-range-start.md), [20260727_inner-word-anchor-via-word-end.md](../../decisions/references/20260727_inner-word-anchor-via-word-end.md))
+
+**단일 청크(≤8타) 편집 그룹은 페이싱 대상**이다(`editGroupPaced` — 스트로크 사이 5ms) — 오퍼레이터(`Cmd-X`/`Cmd-C`)·yank collapse `←`의 의미가 선행 스트로크의 착지에 의존해, Notion 0간격 버스트에서 선택이 착지하기 전의 `Cmd-C`가 "선택 없는 `Cmd-C` = 블록 전체 복사"로 터졌다(`y$` 도그푸딩 실측 — `D`/`C`의 `Cmd-X`는 같은 축이 파괴적). 경계가 청크 폭인 것은 카운트 버스트(`500x` = 501타 단일 그룹)를 현행 무페이싱으로 남기기 위해서고, 하이브리드 위임분(`[Cmd-X]`/`[Cmd-C, ←]`)은 접두가 AX 쓰기 + 되읽어 검증이라 페이싱 밖이다 ([20260831_edit-group-stroke-pacing.md](../../decisions/references/20260831_edit-group-stroke-pacing.md)).
 
 **정확화 표** — 읽기가 증명하면 시퀀스가 갈리고, 증명하지 못하면 무상태 시퀀스가 그대로 나간다. 전부 캐럿(`selection.length == 0`)일 때만 발동한다(살아 있는 선택은 출발점 증명 불가).
 

--- a/.claude/skills/decisions/SKILL.md
+++ b/.claude/skills/decisions/SKILL.md
@@ -198,6 +198,7 @@ description: VimAction 프로젝트의 기술 결정 히스토리 SSOT — 아�
 | 08-06 | 스크롤 줄 수 우선순위 사다리 | 프로파일 명시값 > AX 뷰포트 > 상수 15/30 (extent별 독립) — 명시 extent는 술어가 읽기 생략 | [20260806_scroll-line-count-priority-ladder.md](references/20260806_scroll-line-count-priority-ladder.md) |
 | 08-06 | 뷰포트 줄 수 클램프만·무페이싱 | `min(max(1,n),200)`(파서 상한 정렬·음수 트랩 가드), half=n/2·full=n−2(Vim 겹침), 스크롤 페이싱 없음 유지 | [20260806_scroll-viewport-clamp-no-pacing.md](references/20260806_scroll-viewport-clamp-no-pacing.md) |
 | 08-06 | 비-QWERTY 역조회 치환 | KeyTranslator가 z/x/c/v 키코드 역조회 캐시, 어댑터가 게시 직전 6/7/8/9 치환(QWERTY는 생략) — layoutBlocked는 역조회 실패 시 최후 방어선 | [20260806_non-qwerty-command-key-reverse-lookup.md](references/20260806_non-qwerty-command-key-reverse-lookup.md) |
+| 08-31 | 편집 그룹도 페이싱 — 단일 청크 한정 | Notion 버스트에서 선택 착지 전 Cmd-C가 블록 전체 복사(`y$` 실측, D/C는 파괴적) — ≤8타 편집 그룹만 5ms 페이싱, 카운트 버스트·하이브리드 위임분은 현행, 20260805 부분 supersede | [20260831_edit-group-stroke-pacing.md](references/20260831_edit-group-stroke-pacing.md) |
 
 ### 실행 계층 — Visual 시퀀스
 

--- a/.claude/skills/decisions/references/20260805_visual-refined-group-stroke-pacing.md
+++ b/.claude/skills/decisions/references/20260805_visual-refined-group-stroke-pacing.md
@@ -1,4 +1,5 @@
 > Superseded (부분) by [20260806_paste-groups-stroke-pacing.md](20260806_paste-groups-stroke-pacing.md) — 페이싱 범위에 `.paste` 그룹 추가 / 5ms 상수·정확화 그룹 페이싱·스크롤 등 타이밍 현행 유지 원칙은 유효
+> Superseded (부분) by [20260831_edit-group-stroke-pacing.md](20260831_edit-group-stroke-pacing.md) — "무상태 다타는 드롭 미관측이라 페이싱 안 함" 문언에 편집 그룹(단일 청크 한정)이 반례로 추가 / 스크롤·카운트 버스트 현행 유지 원칙은 유효
 
 # Visual 정확화 그룹 한정 스트로크 페이싱 (5ms)
 

--- a/.claude/skills/decisions/references/20260831_edit-group-stroke-pacing.md
+++ b/.claude/skills/decisions/references/20260831_edit-group-stroke-pacing.md
@@ -1,0 +1,59 @@
+# 편집 그룹도 스트로크 페이싱 — 단일 청크 한정
+
+<!-- 파일명 규칙: yyyymmdd_<kebab-case-title>.md — 날짜는 결정일. 이 문서는 결정의 불변 스냅샷이며, 기록 후 수정하지 않습니다 (Superseded 마킹 1줄 제외). -->
+
+- **결정일**: 2026-08-31
+
+## 결정
+
+keyboard 편집 그룹(`classifyEdit`의 `.groups`)을 **단일 청크(≤ `chunkStrokes` = 8타)에 담기는
+경우에 한해** 페이싱 대상(`paced: true`)에 넣는다 — 판정은 순수 함수
+`KeyboardAdapter.editGroupPaced(strokeCount:)` 하나다. 카운트 버스트(`500x` = 501타 단일
+그룹)는 "카운트 버스트·스크롤 타이밍 현행 유지" 제약대로 페이싱 밖에 남고, 하이브리드
+위임분(`[Cmd-X]`/`[Cmd-C, ←]` — 접두가 AX 쓰기 + 되읽어 검증이라 버스트 취약 축이 없다)과
+`.edit(_, .selection)` 1타 그룹(게시 쪽 "2타 미만은 일반 경로" 규칙)도 현행 그대로다.
+
+## 배경·근거 (왜)
+
+`Y`(=`y$`) 도그푸딩 실측: Notion에서 `y$`/`Y`가 커서 오른쪽이 아니라 **줄 전체를 복사**했다
+(Apple Notes는 정상). 판별 실측 2건 — ① `y$`도 동일 재현(Y 매핑 무관), ② 손 입력
+`Shift-Cmd-→` → `Cmd-C`는 정상 — 으로 시맨틱 충돌이 아니라 **간격 문제로 확정**됐다.
+재앵커([20260805](20260805_visual-refined-group-stroke-pacing.md))·paste
+접두([20260806](20260806_paste-groups-stroke-pacing.md))와 같은 약점·같은 대응이다.
+
+메커니즘: 편집 그룹은 오퍼레이터의 의미가 직전 선택 스트로크의 착지에 의존하는 형태인데
+(`[Shift-Cmd-→, Cmd-C, ←]`), 0간격 버스트에서 선택이 착지하기 전에 `Cmd-C`가 처리되면
+Notion의 **"선택 없는 `Cmd-C` = 블록 전체 복사"** 자체 의미론이 발동한다. 같은 축이
+`d$`/`c$`(`D`/`C`)에서는 **블록 전체 잘라내기라 파괴적**이다 — 수용이 아니라 수정 대상.
+
+이는 20260805의 "무상태 다타(`dd` 3타 등)는 Notion 포함 실사용에서 드롭이 관측된 적 없어
+페이싱하지 않는다" 전제의 **첫 반례**다. 관측 공백의 이유도 설명된다 — linewise 편집
+(`yy`/`dd`)에서는 선택이 유실돼도 블록 전체 복사/잘라내기가 의도 결과와 거의 같아 증상이
+가려졌고, charwise mid-line yank(`y$`)가 처음으로 가시화했다.
+
+경계를 청크 폭으로 한정한 이유: 그룹 전체 무조건 페이싱은 `500x`가 501타 × 5ms ≈ 2.5s로
+기존 제약과 정면 충돌한다. 청크 폭 재사용은 무상태 편집 시퀀스 전부(최대 5~6타)를 덮으면서
+비용 상한이 7 × 5ms = 35ms이고, 임의 상수를 새로 만들지 않는다. 경계 밖(9타 이상 —
+카운트 곱 편집)은 무페이싱 = 현행 동작이라 회귀 방향이 없다.
+
+## 검토한 대안
+
+- **오퍼레이터 경계만 페이싱(suffix)**: 카운트 무관 균일하지만 `Mapping`에 suffix 표현을
+  신설해야 하고, `dd`/`yy`의 이질적 선택 접두(collapse → 이동 → Shift 확장 — 20260805가
+  실측한 실패 형태 그대로)는 미방어로 남는다. 기존 paced 기계 재사용이 더 작고 넓다.
+- **Notion 프로파일 한정 적용**: 페이싱은 프로파일 어휘가 아니고, 20260805·20260806 선례가
+  전역 적용이다(수 타 × 5ms는 어디서나 무해).
+- **앱 시맨틱 수용**: `D`/`C`의 블록 잘라내기라는 파괴 축이 있어 불가.
+
+## 영향 범위
+
+- `VimAction/KeyboardAdapter.swift`: `classifyEdit`의 `paced` 판정, `editGroupPaced` 신설,
+  `Mapping.groups`·`pacedStrokeInterval`·하이브리드 위임분 주석 갱신
+- 테스트: `KeyboardAdapterEditPacingTests` (경계표 + 페이싱 게시 배선의 경과 시간 하한 단언)
+- 갱신한 architecture reference: [keyboard-adapter.md](../../architecture/references/keyboard-adapter.md)
+
+## Supersedes
+
+- [20260805_visual-refined-group-stroke-pacing.md](20260805_visual-refined-group-stroke-pacing.md)
+  **부분** — "무상태 다타는 드롭 미관측이라 페이싱하지 않는다" 문언에 편집 그룹이 반례로
+  추가된다. 5ms 상수·정확화 그룹 페이싱·스크롤/카운트 버스트 타이밍 현행 유지 원칙은 유효.

--- a/VimAction/KeyboardAdapter.swift
+++ b/VimAction/KeyboardAdapter.swift
@@ -569,11 +569,23 @@ nonisolated struct KeyboardAdapter: Sendable {
     /// 게시 직렬 큐를 막는 것이 곧 스로틀이며, 새 키는 탭 콜백에서 래치만 세우고 그 뒤에 쌓인다.
     private static let chunkInterval: TimeInterval = 0.002
 
-    /// 페이싱 다타 그룹(Visual 정확화·paste 접두)의 스트로크 간 간격 — 도그푸딩
-    /// 조절값이다 (Notion 실측: 5ms 충분 확인, 최솟값 미탐). `chunkInterval`과 달리 중단
-    /// 장치가 아니라 **대상 앱이 각 스트로크의 의미(collapse·이동 → Shift 확장·Cmd-V)를
-    /// 소화할 시간**이다.
+    /// 페이싱 다타 그룹(Visual 정확화·paste 접두·단일 청크 편집)의 스트로크 간 간격 —
+    /// 도그푸딩 조절값이다 (Notion 실측: 5ms 충분 확인, 최솟값 미탐). `chunkInterval`과 달리
+    /// 중단 장치가 아니라 **대상 앱이 각 스트로크의 의미(collapse·이동 → Shift 확장·
+    /// Cmd-V·Cmd-C)를 소화할 시간**이다.
     private static let pacedStrokeInterval: TimeInterval = 0.005
+
+    /// 편집 그룹 페이싱 판정 — **단일 청크에 담기는 편집 그룹만** 페이싱한다.
+    ///
+    /// 편집 그룹은 오퍼레이터(`Cmd-X`/`Cmd-C`)의 의미가 직전 선택 스트로크의 착지에,
+    /// yank collapse `←`가 다시 `Cmd-C`의 착지에 의존하는 형태다 — Notion 0간격 버스트에서
+    /// 선택이 착지하기 전에 오퍼레이터가 처리되면 "선택 없는 `Cmd-C`/`Cmd-X` = 블록 전체
+    /// 복사/잘라내기"라는 앱 자체 의미론이 발동한다 (`y$` 도그푸딩 실측 — 재앵커·paste
+    /// 접두와 같은 약점·같은 대응). 카운트 버스트(`500x` = 501타 단일 그룹)는 "카운트
+    /// 버스트 타이밍 현행 유지" 제약대로 페이싱 밖이다 — 경계는 청크 폭을 재사용한다.
+    static func editGroupPaced(strokeCount: Int) -> Bool {
+        strokeCount <= chunkStrokes
+    }
 
     /// 되읽어 검증의 폴링 간격 — 도그푸딩 조절값이다.
     ///
@@ -720,11 +732,13 @@ nonisolated struct KeyboardAdapter: Sendable {
         /// **원자 그룹**의 목록. 청크 경계는 그룹 사이에만 올 수 있다 — 대부분의 액션은
         /// 그룹 1개(액션 전체)이고, `.paste`만 카운트만큼 갈라져 온다.
         ///
-        /// `paced`는 **Visual 정확화 그룹과 `.paste`** 만 참이다 — 다타 그룹의 스트로크
-        /// 사이에 고정 간격을 둔다 (Notion 실측: 0간격 버스트는 재앵커의 Shift 확장도,
-        /// 붙여넣기 접두의 화살표도 소화하지 못했고, 이벤트당 5ms에서는 완전 정상 — 간격
-        /// 문제로 확정). 범위를 이 둘로 한정해야 스크롤(단일 화살표 그룹 — 뷰포트 유래면
-        /// 최대 200타)·폴백 카운트 반복(`500x`)·카운트 버스트가 타이밍까지 현행 그대로다.
+        /// `paced`는 **Visual 정확화 그룹·`.paste`·단일 청크 편집 그룹**만 참이다 — 다타
+        /// 그룹의 스트로크 사이에 고정 간격을 둔다 (Notion 실측: 0간격 버스트는 재앵커의
+        /// Shift 확장도, 붙여넣기 접두의 화살표도 소화하지 못했고, 선택이 착지하기 전의
+        /// `Cmd-C`는 블록 전체 복사가 됐다. 이벤트당 5ms에서는 완전 정상 — 간격 문제로
+        /// 확정). 편집이 청크 폭으로 잘리는 것은(`editGroupPaced`) 스크롤(단일 화살표
+        /// 그룹 — 뷰포트 유래면 최대 200타)·폴백 카운트 반복(`500x`)·카운트 버스트를
+        /// 타이밍까지 현행 그대로 두기 위해서다.
         /// 스크롤이 계속 무페이싱인 것은 드롭의 실패 방향이 "덜 스크롤"이라 무해해서다.
         case groups([[KeyStroke]], paced: Bool)
         /// **AX 쓰기 계획** — `AXSelectedTextRange`에 쓸 범위다(길이 0이면 캐럿).
@@ -1006,8 +1020,11 @@ nonisolated struct KeyboardAdapter: Sendable {
                     // `nil`(= `char_left` disable)이면 아래 위임으로 낙하해 기존 경로가
                     // `.disabledByProfile`로 정직하게 집계한다.
                     if let operatorKeys = EditKeyMapper.operatorStrokes(for: op, profile: profile) {
-                        // 위임분은 `[Cmd-X]` 또는 `[Cmd-C, ←]` 한 그룹이고, 현행 keyboard 편집이
-                        // 무페이싱이라 그대로 둔다 (`.paste`만 `paced: true`다).
+                        // 위임분은 `[Cmd-X]` 또는 `[Cmd-C, ←]` 한 그룹으로 무페이싱 유지 —
+                        // keyboard 편집 그룹의 페이싱(`editGroupPaced`)은 버스트에 취약한
+                        // 앱에서 선택 스트로크가 착지하기 전에 오퍼레이터가 처리되는 축인데,
+                        // 하이브리드의 선택은 AX 쓰기 + 되읽어 검증으로 이미 착지가 확인된
+                        // 상태라 그 축이 없다.
                         hybrid = .hybrid(span, [operatorKeys], paced: false)
                     }
                 case .invalid:
@@ -1240,7 +1257,9 @@ nonisolated struct KeyboardAdapter: Sendable {
     ) -> Mapping {
         if let strokes = EditKeyMapper.keyStrokes(
             for: op, range: range, family: family, profile: profile, text: text) {
-            return .groups([strokes], paced: false)
+            // 페이싱 사유·청크 폭 경계는 `editGroupPaced` 참고. `.selection`(`Cmd-X`/`Cmd-C`
+            // 1타)은 참이어도 게시 쪽 "2타 미만은 일반 경로" 규칙에 걸려 현행 그대로다.
+            return .groups([strokes], paced: Self.editGroupPaced(strokeCount: strokes.count))
         }
         // ① 텍스트 프로브 — **`builtIn`보다 앞**이다. 읽기 없이 답이 있었다면 `nil`을 만든 것은
         //    미지원도 프로파일도 아니라 정확화다.

--- a/VimActionTests/KeyboardAdapterTests.swift
+++ b/VimActionTests/KeyboardAdapterTests.swift
@@ -861,7 +861,7 @@ struct KeyboardAdapterEditPacingTests {
                 Int64(kVK_ANSI_C), Int64(kVK_ANSI_C),
                 Int64(kVK_LeftArrow), Int64(kVK_LeftArrow),
             ])
-        #expect(elapsed >= .milliseconds(9))
+        #expect(elapsed >= .milliseconds(10))
     }
 }
 

--- a/VimActionTests/KeyboardAdapterTests.swift
+++ b/VimActionTests/KeyboardAdapterTests.swift
@@ -828,6 +828,43 @@ struct KeyboardAdapterAbortTests {
     }
 }
 
+/// 편집 그룹 페이싱 — **단일 청크(≤8타) 편집 그룹만** 스트로크 사이 간격을 두고 게시한다.
+///
+/// 오퍼레이터(`Cmd-X`/`Cmd-C`)의 의미가 직전 선택 스트로크의 착지에 의존하는데, Notion은
+/// 0간격 버스트에서 선택이 착지하기 전에 오퍼레이터를 처리해 "선택 없는 `Cmd-C` = 블록
+/// 전체 복사"가 됐다 (`y$` 도그푸딩 실측 — `20260831_edit-group-stroke-pacing.md`).
+struct KeyboardAdapterEditPacingTests {
+    /// 경계는 청크 폭(8) 재사용이다 — 카운트 버스트(`500x` = 501타 단일 그룹)는 "카운트
+    /// 버스트 타이밍 현행 유지" 제약대로 페이싱 밖에 남는다.
+    @Test(
+        "편집 그룹 페이싱 경계는 청크 폭이다",
+        arguments: [(2, true), (3, true), (8, true), (9, false), (501, false)])
+    func editGroupPacedBoundary(_ strokeCount: Int, _ paced: Bool) {
+        #expect(KeyboardAdapter.editGroupPaced(strokeCount: strokeCount) == paced)
+    }
+
+    /// 배선 검증 — 판정만 참이고 게시가 일반 경로면 죽은 코드다. 페이싱의 스트로크 간
+    /// sleep은 **보장 하한**이라 경과 시간의 하한 단언은 흔들리지 않는다 (느린 머신은 더
+    /// 오래 걸릴 뿐이다). `y$` = `[Shift-Cmd-→, Cmd-C, ←]` 3타 → 간격 2회 ≥ 10ms.
+    @Test("y$ 편집 그룹은 페이싱 게시된다")
+    func lineEndYankPostsPaced() {
+        nonisolated(unsafe) var posted: [CGEvent] = []
+        let adapter = makeAdapter { posted.append($0) }
+
+        let elapsed = ContinuousClock().measure {
+            adapter.execute([.edit(.yank, .motion(.lineEnd, count: 1))])
+        }
+
+        #expect(
+            keyCodes(of: posted) == [
+                Int64(kVK_RightArrow), Int64(kVK_RightArrow),
+                Int64(kVK_ANSI_C), Int64(kVK_ANSI_C),
+                Int64(kVK_LeftArrow), Int64(kVK_LeftArrow),
+            ])
+        #expect(elapsed >= .milliseconds(9))
+    }
+}
+
 /// 요소 계열 게이트 — 리졸버가 보고한 계열에 따라 어댑터가 무엇을 걸러내는가.
 ///
 /// 걸러내기는 시퀀스 다변화가 아니다: `.textField`는 `o`/`O`만, `.nonText`는 편집·Visual·명령


### PR DESCRIPTION
## Summary

Dogfooding `Y` (#61) surfaced a **pre-existing** keyboard-path bug in Notion: `y$` / `Y` copied the whole line instead of cursor-to-line-end. The edit group `[Shift-Cmd-→, Cmd-C, ←]` is posted as a zero-gap burst; Notion processes `Cmd-C` before the selection has landed, and its own "`Cmd-C` with no selection copies the whole block" semantics fire. `d$` / `c$` (`D` / `C`) share the same axis destructively — `Cmd-X` on an unsettled selection cuts the whole block.

The fix paces keyboard edit groups that fit in a single chunk (**≤ 8 strokes**) with the existing 5ms stroke interval (`editGroupPaced`, one pure function). Count bursts (`500x` = a 501-stroke group) stay unpaced per the existing "count-burst timing unchanged" constraint; hybrid operator groups stay unpaced (their prefix is an AX write with read-back verification); `.edit(_, .selection)` single-stroke groups fall under the existing "< 2 strokes = normal path" rule.

## Diagnosis

- `y$` reproduces identically → not specific to the new `Y` mapping (the engine emits the same action).
- Hand-typed `Shift-Cmd-→` then `Cmd-C` works fine → an **interval** problem, not a shortcut conflict — the same weakness the reanchor (2026-08-05) and paste-prefix (2026-08-06) pacing decisions measured, with the same 5ms response.
- First counterexample to 2026-08-05's "stateless multi-stroke groups showed no drops" premise: linewise edits (`yy` / `dd`) masked the failure because a whole-block copy/cut is nearly the intended result; the charwise mid-line yank made it visible.

## Decisions

Recorded in [`.claude/skills/decisions/references/20260831_edit-group-stroke-pacing.md`](.claude/skills/decisions/references/20260831_edit-group-stroke-pacing.md) — the boundary reuses the chunk width (no new constant; cost cap 7 × 5ms = 35ms), and rejected alternatives are operator-suffix-only pacing (new `Mapping` machinery, leaves the heterogeneous `dd` selection prefix uncovered), Notion-profile-only scoping (pacing is not profile vocabulary; precedent is global), and accepting the app semantics (impossible — `D`/`C` is destructive).

## Test plan

- `xcodebuild test … -only-testing:VimActionTests` — **TEST SUCCEEDED**, 0 warnings. New `KeyboardAdapterEditPacingTests`: pacing boundary table (2/3/8 paced, 9/501 not) + wiring test asserting the paced posting path via an elapsed-time **lower bound** (sleep is a guaranteed minimum, so it cannot flake toward failure).
- Dogfooding on this build: `Y` / `y$` mid-line in Notion should copy cursor→line-end; `D` on a throwaway line should delete only the right of the cursor.

**Merge gate: draft until Notion dogfooding confirms the fix.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL8eWwCPGSMngjTxN9pnjo